### PR TITLE
[DRUP-370] auth changes

### DIFF
--- a/modules/add_credit/src/Job/BalanceAdjustmentJob.php
+++ b/modules/add_credit/src/Job/BalanceAdjustmentJob.php
@@ -252,16 +252,8 @@ class BalanceAdjustmentJob extends EdgeJob {
    * @throws \Exception
    */
   protected function getPrepaidBalance(PrepaidBalanceControllerInterface $controller, $currency_code) {
-    try {
-      /** @var \Apigee\Edge\Api\Monetization\Entity\PrepaidBalanceInterface[] $balances */
-      $balances = $controller->getPrepaidBalance(new \DateTimeImmutable());
-    }
-    catch (ApiResponseException $e) {
-      // A 204 response is normal for an account with no balance.
-      if ($e->getResponse()->getStatusCode() !== 204) {
-        throw $e;
-      }
-    }
+    /** @var \Apigee\Edge\Api\Monetization\Entity\PrepaidBalanceInterface[] $balances */
+    $balances = $controller->getPrepaidBalance(new \DateTimeImmutable());
 
     if (!empty($balances)) {
       $balances = array_combine(array_map(function ($balance) {

--- a/modules/add_credit/tests/Kernel/BalanceAdjustmentJobKernelTest.php
+++ b/modules/add_credit/tests/Kernel/BalanceAdjustmentJobKernelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * Copyright 2018 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -147,7 +147,7 @@ class BalanceAdjustmentJobKernelTest extends MonetizationKernelTestBase {
     $this->stack
       // Queue an empty balance response because this is what you get with a new
       // user.
-      ->queueMockResponse('no_content')
+      ->queueMockResponse('get_prepaid_balances_empty')
       // Queue a developer balance response for the top up (POST).
       ->queueMockResponse(['post_developer_balances' => ['amount' => '19.99']])
       // Queue an updated balance response.

--- a/tests/modules/apigee_m10n_test/apigee_m10n_test.info.yml
+++ b/tests/modules/apigee_m10n_test/apigee_m10n_test.info.yml
@@ -1,0 +1,9 @@
+name: 'Apigee Monetization: Testing'
+type: module
+description: 'Support module for the Apigee Monetization tests.'
+core: 8.x
+package: Testing
+
+dependencies:
+  - apigee_edge:apigee_edge
+  - apigee_m10n:apigee_m10n

--- a/tests/modules/apigee_m10n_test/apigee_m10n_test.module
+++ b/tests/modules/apigee_m10n_test/apigee_m10n_test.module
@@ -1,6 +1,7 @@
 <?php
 
-/*
+/**
+ * @file
  * Copyright 2018 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -17,22 +18,18 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-namespace Drupal\apigee_m10n;
+/**
+ * @file
+ * Helper module for the apigee_m10n tests.
+ */
+
+use Drupal\apigee_m10n_test\Plugin\KeyProvider\TestEnvironmentVariablesKeyProvider;
 
 /**
- * Environment variable keys.
- *
- * @package Drupal\apigee_m10n
+ * Implements hook_key_provider_info_alter().
  */
-abstract class EnvironmentVariable {
-  const APIGEE_EDGE_AUTH_TYPE = 'APIGEE_EDGE_AUTH_TYPE';
-  const APIGEE_EDGE_ENDPOINT = 'APIGEE_EDGE_ENDPOINT';
-  const APIGEE_EDGE_ORGANIZATION = 'APIGEE_EDGE_ORGANIZATION';
-  const APIGEE_EDGE_USERNAME = 'APIGEE_EDGE_USERNAME';
-  const APIGEE_EDGE_PASSWORD = 'APIGEE_EDGE_PASSWORD';
-  const APIGEE_INTEGRATION_ENABLE = 'APIGEE_INTEGRATION_ENABLE';
-  const APIGEE_EDGE_AUTHORIZATION_SERVER = 'APIGEE_EDGE_AUTHORIZATION_SERVER';
-  const APIGEE_EDGE_CLIENT_ID = 'APIGEE_EDGE_CLIENT_ID';
-  const APIGEE_EDGE_CLIENT_SECRET = 'APIGEE_EDGE_CLIENT_SECRET';
-
+function apigee_m10n_test_key_provider_info_alter(array &$key_providers) {
+  // This key provider override will make sure credentials are available during
+  // functional test callbacks.
+  $key_providers['apigee_edge_environment_variables']['class'] = TestEnvironmentVariablesKeyProvider::class;
 }

--- a/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
+++ b/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_test\Plugin\KeyProvider;
+
+use Drupal\apigee_edge\Plugin\KeyProvider\EnvironmentVariablesKeyProvider;
+use Drupal\Core\State\StateInterface;
+use Drupal\key\KeyInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Overrides the `apigee_edge_environment_variables` plugin.
+ */
+class TestEnvironmentVariablesKeyProvider extends EnvironmentVariablesKeyProvider {
+
+  const KEY_VALUE_STATE_ID = 'apigee_m10n_test_key_value';
+
+  /**
+   * Drupal state.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StateInterface $state) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('state')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setKeyValue(KeyInterface $key, $key_value) {
+    // Store the value in state for functional callbacks.
+    $this->state->set(static::KEY_VALUE_STATE_ID, $key_value);
+
+    return parent::setKeyValue($key, $key_value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getKeyValue(KeyInterface $key) {
+    $key_value = parent::getKeyValue($key);
+
+    // If the key_value is empty during a request callback get credentials from
+    // state.
+    $key_value = (!empty($key_value) && $key_value !== '{}') ? $key_value
+      : $this->state->get(static::KEY_VALUE_STATE_ID);
+
+    return $key_value;
+  }
+
+}

--- a/tests/src/Functional/MonetizationFunctionalTestBase.php
+++ b/tests/src/Functional/MonetizationFunctionalTestBase.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * Copyright 2018 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -20,7 +20,6 @@
 namespace Drupal\Tests\apigee_m10n\Functional;
 
 use Drupal\Tests\apigee_m10n\Traits\ApigeeMonetizationTestTrait;
-use Drupal\apigee_m10n\EnvironmentVariable;
 use Drupal\Tests\BrowserTestBase;
 
 /**
@@ -36,8 +35,7 @@ class MonetizationFunctionalTestBase extends BrowserTestBase {
   }
 
   protected static $modules = [
-    'apigee_edge',
-    'apigee_m10n',
+    'apigee_m10n_test',
     'apigee_mock_client',
     'system',
   ];
@@ -61,8 +59,6 @@ class MonetizationFunctionalTestBase extends BrowserTestBase {
    */
   protected function setUp() {
     parent::setUp();
-
-    $this->integration_enabled = !empty(getenv(EnvironmentVariable::$APIGEE_EDGE_ENDPOINT));
 
     // Create new Apigee Edge basic auth key.
     $this->init();

--- a/tests/src/FunctionalJavascript/MonetizationFunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/MonetizationFunctionalJavascriptTestBase.php
@@ -21,7 +21,6 @@ namespace Drupal\Tests\apigee_m10n\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\Tests\apigee_m10n\Traits\ApigeeMonetizationTestTrait;
-use Drupal\apigee_m10n\EnvironmentVariable;
 
 /**
  * Setup for functional javascript tests.
@@ -36,8 +35,7 @@ class MonetizationFunctionalJavascriptTestBase extends WebDriverTestBase {
   }
 
   protected static $modules = [
-    'apigee_edge',
-    'apigee_m10n',
+    'apigee_m10n_test',
     'apigee_mock_client',
     'system',
   ];
@@ -61,8 +59,6 @@ class MonetizationFunctionalJavascriptTestBase extends WebDriverTestBase {
    */
   protected function setUp() {
     parent::setUp();
-
-    $this->integration_enabled = !empty(getenv(EnvironmentVariable::$APIGEE_EDGE_ENDPOINT));
 
     // Create new Apigee Edge basic auth key.
     $this->init();

--- a/tests/src/Kernel/MonetizationKernelTestBase.php
+++ b/tests/src/Kernel/MonetizationKernelTestBase.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * Copyright 2018 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -21,7 +21,6 @@ namespace Drupal\Tests\apigee_m10n\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\apigee_m10n\Traits\ApigeeMonetizationTestTrait;
-use Drupal\apigee_m10n\EnvironmentVariable;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
@@ -42,6 +41,7 @@ class MonetizationKernelTestBase extends KernelTestBase {
     'file',
     'apigee_edge',
     'apigee_m10n',
+    'apigee_m10n_test',
     'apigee_mock_client',
     'user',
     'system',
@@ -63,8 +63,6 @@ class MonetizationKernelTestBase extends KernelTestBase {
     parent::setUp();
 
     $this->installConfig(['apigee_edge', 'apigee_m10n']);
-
-    $this->integration_enabled = !empty(getenv(EnvironmentVariable::$APIGEE_INTEGRATION_ENABLE));
 
     $this->init();
   }


### PR DESCRIPTION
Since `apigee_edge` 8.x-1.x-beta1 was released, the key module plugins we are using have been deprecated and removed.

Commit:563b134 removes an unnecessary try/catch that was added in commit:8fa5094 and queues the correct response.