### PR TITLE
[DRU-401] Add a patch to fix a core issue where `RevisionableInterfac…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
     "extra": {
         "patches": {
             "apigee/apigee-client-php": {
-              "Fix developer ID issue when unsubscribing from a rate plan": "https://github.com/apigee/apigee-client-php/files/2627181/unsubscribe-rate-plan-developer-id.patch.txt"
+                "Fix developer ID issue when unsubscribing from a rate plan": "https://github.com/apigee/apigee-client-php/files/2627181/unsubscribe-rate-plan-developer-id.patch.txt"
+            },
+            "drupal/core": {
+                "`EntityViewBuilder::getBuildDefaults()` doesn't check for `RevisionableInterface`.": "https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch"
             }
         }
     }


### PR DESCRIPTION
This patch is needed in order to render any entity that doesn't implement `RevisionableInterface`.

For monetization entities re add `isDefaultRevision` and just return `TRUE` but edge entities don't and that breaks how entity references are rendered.
