### PR TITLE
[DRUP-526] Update tests to use the latest dev version of `apigee_m10n`

### DIFF
--- a/tests/modules/apigee_mock_client/tests/response-templates/get-not-found.json.twig
+++ b/tests/modules/apigee_mock_client/tests/response-templates/get-not-found.json.twig
@@ -10,7 +10,7 @@
  */
 #}
 {
-    "code" : "mint.resourceDoesNotExist",
-    "message" : "{{ message|default('The requested object does nto exist.') }}",
+    "code" : "{{ code|default('mint.resourceDoesNotExist') }}",
+    "message" : "{{ message|default('The requested object does not exist.') }}",
     "contexts" : [ ]
 }

--- a/tests/src/Functional/BillingDetailsTest.php
+++ b/tests/src/Functional/BillingDetailsTest.php
@@ -59,7 +59,6 @@ class BillingDetailsTest extends MonetizationFunctionalTestBase {
    * Tests permissions for `Billing Details` page.
    */
   public function testBillingDetailsAccessDenied() {
-    $this->queueOrg();
     $this->drupalGet(Url::fromRoute('apigee_monetization.profile', [
       'user' => $this->developer->id(),
     ]));

--- a/tests/src/Functional/NavigationTest.php
+++ b/tests/src/Functional/NavigationTest.php
@@ -63,7 +63,6 @@ class NavigationTest extends MonetizationFunctionalTestBase {
 
     $this->drupalLogin($this->developer);
 
-    $this->queueOrg();
     // Check the manage profile link.
     $this->clickLink('My account');
 

--- a/tests/src/Functional/PrepaidBalanceTest.php
+++ b/tests/src/Functional/PrepaidBalanceTest.php
@@ -50,7 +50,6 @@ class PrepaidBalanceTest extends MonetizationFunctionalTestBase {
     $this->developer = $this->createAccount([]);
 
     $this->drupalLogin($this->developer);
-    $this->queueOrg();
     $this->drupalGet(Url::fromRoute('apigee_monetization.billing', [
       'user' => $this->developer->id(),
     ]));

--- a/tests/src/Functional/SubscriptionListTest.php
+++ b/tests/src/Functional/SubscriptionListTest.php
@@ -83,8 +83,7 @@ class SubscriptionListTest extends MonetizationFunctionalTestBase {
 
     $this->queueOrg();
     $this->stack
-      ->queueMockResponse(['get_developer_subscriptions' => ['subscriptions' => [$subscription]]])
-      ->queueMockResponse(['get_package_rate_plan' => ['plan' => $rate_plan]]);
+      ->queueMockResponse(['get_developer_subscriptions' => ['subscriptions' => [$subscription]]]);
 
     $this->drupalGet(Url::fromRoute('entity.subscription.collection_by_developer', [
       'user' => $this->developer->id(),

--- a/tests/src/Functional/SubscriptionListTest.php
+++ b/tests/src/Functional/SubscriptionListTest.php
@@ -60,7 +60,6 @@ class SubscriptionListTest extends MonetizationFunctionalTestBase {
    * Tests permissions for `My Plans/Subscriptions` page.
    */
   public function testSubscriptionListAccessDenied() {
-    $this->queueOrg();
     $this->drupalGet(Url::fromRoute('entity.subscription.collection_by_developer', [
       'user' => $this->developer->id(),
     ]));

--- a/tests/src/Kernel/Controller/PackageControllerKernelTest.php
+++ b/tests/src/Kernel/Controller/PackageControllerKernelTest.php
@@ -55,6 +55,25 @@ class PackageControllerKernelTest extends MonetizationKernelTestBase {
     $this->installConfig([
       'user',
     ]);
+
+    // User install is going to try to create a developer for the root user.
+    $this->stack->queueMockResponse([
+      'get_not_found'  => [
+        'status_code' => 404,
+        'code' => 'developer.service.DeveloperIdDoesNotExist',
+        'message' => 'DeveloperId v1 does not exist in organization foo-org',
+      ],
+    ])->queueMockResponse([
+      'get_developer' => [
+        'status_code' => 201,
+      ],
+    ])->queueMockResponse([
+      // The call to save happens twice in a row because of `setStatus()`.
+      // See: \Drupal\apigee_edge\Entity\Storage\DeveloperStorage::doSave()`.
+      'get_developer' => [
+        'status_code' => 201,
+      ],
+    ]);
     // Install user 0 and user 1.
     \user_install();
 
@@ -169,9 +188,6 @@ class PackageControllerKernelTest extends MonetizationKernelTestBase {
       ->queueMockResponse(['get_monetization_packages' => ['packages' => $sdk_packges]]);
 
     foreach ($sdk_packges as $package) {
-      foreach ($package->getApiProducts() as $api_product) {
-        $this->stack->queueMockResponse(['api_product' => ['product' => $api_product]]);
-      }
       $this->stack->queueMockResponse(['get_monetization_package_plans' => ['plans' => [$rate_plans[$package->id()]]]]);
     }
 

--- a/tests/src/Kernel/Controller/PackageControllerKernelTest.php
+++ b/tests/src/Kernel/Controller/PackageControllerKernelTest.php
@@ -188,6 +188,12 @@ class PackageControllerKernelTest extends MonetizationKernelTestBase {
       ->queueMockResponse(['get_monetization_packages' => ['packages' => $sdk_packges]]);
 
     foreach ($sdk_packges as $package) {
+      foreach ($package->getApiProducts() as $api_product) {
+        if (!$this->container->has('apigee_edge.controller.cache.api_product')) {
+          // TODO: Remove this queue when `apigee_edge` beta 2 is released.
+          $this->stack->queueMockResponse(['api_product' => ['product' => $api_product]]);
+        }
+      }
       $this->stack->queueMockResponse(['get_monetization_package_plans' => ['plans' => [$rate_plans[$package->id()]]]]);
     }
 

--- a/tests/src/Kernel/Controller/PackageControllerKernelTest.php
+++ b/tests/src/Kernel/Controller/PackageControllerKernelTest.php
@@ -175,19 +175,19 @@ class PackageControllerKernelTest extends MonetizationKernelTestBase {
       $this->createPackage(),
       $this->createPackage(),
     ];
-    $sdk_packges = [];
+    $sdk_packages = [];
     $rate_plans = [];
     foreach ($packages as $package) {
       $rate_plans[$package->id()] = $this->createPackageRatePlan($package);
-      $sdk_packges[] = $package->decorated();
+      $sdk_packages[] = $package->decorated();
     }
 
     $page_controller = PackagesController::create($this->container);
 
     $this->stack
-      ->queueMockResponse(['get_monetization_packages' => ['packages' => $sdk_packges]]);
+      ->queueMockResponse(['get_monetization_packages' => ['packages' => $sdk_packages]]);
 
-    foreach ($sdk_packges as $package) {
+    foreach ($sdk_packages as $package) {
       foreach ($package->getApiProducts() as $api_product) {
         if (!$this->container->has('apigee_edge.controller.cache.api_product')) {
           // TODO: Remove this queue when `apigee_edge` beta 2 is released.


### PR DESCRIPTION
Some changes to the Apigee Edge module are causing the tests to fail. These fixes will ensure the tests pass using the latest or beta1