### PR TITLE
Revert "[DRUP-575] Use composer to update drupal core."

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -396,8 +396,6 @@ class RoboFile extends \Robo\Tasks
       $config->require->{"drupal/commerce"} = "~2.0";
       $config->require->{"drupal/token"} = "~1.0";
 
-      // Remove `replace` so drupal core get's updated.
-      unset($config->replace);
       file_put_contents('composer.json', json_encode($config, JSON_PRETTY_PRINT));
     }
 }

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -178,6 +178,13 @@ class RoboFile extends \Robo\Tasks
           ->copy('composer.json', 'artifacts/composer.json')
           ->copy('composer.lock', 'artifacts/composer.lock')
           ->run();
+
+        // Write drush status results to an artifact file.
+        $this->taskExec('vendor/bin/drush status > artifacts/core-stats.txt')->run();
+        $this->taskExec('cat artifacts/core-stats.txt')->run();
+        // Add php info to an artifact file.
+        $this->taskExec('php -i > artifacts/phpinfo.txt')->run();
+        $this->taskExec('cat artifacts/phpinfo.txt')->run();
     }
 
     /**

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -184,7 +184,6 @@ class RoboFile extends \Robo\Tasks
         $this->taskExec('cat artifacts/core-stats.txt')->run();
         // Add php info to an artifact file.
         $this->taskExec('php -i > artifacts/phpinfo.txt')->run();
-        $this->taskExec('cat artifacts/phpinfo.txt')->run();
     }
 
     /**

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ update_dependencies: &update_dependencies
         paths:
           - .
 
+    - store_artifacts:
+        path: /var/www/html/artifacts
+
 # Run Drupal unit and kernel tests as one job. This command invokes the test.sh
 # hook.
 unit_kernel_tests: &unit_kernel_tests

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "behat/mink-extension": "v2.2",
         "behat/mink-selenium2-driver": "1.3.x-dev",
         "bex/behat-screenshot": "^1.2",
+        "consolidation/robo": "~1.0",
         "drupal/coder": "^8.3",
         "drupal/drupal-extension": "master-dev",
         "phpmd/phpmd": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "cweagans/composer-patches": "^1.6",
         "commerceguys/intl": "^1.0",
-        "drupal/apigee_edge": "dev-8.x-1.x-devteams"
+        "drupal/apigee_edge": "dev-8.x-1.x"
     },
     "require-dev": {
         "behat/mink-extension": "v2.2",


### PR DESCRIPTION
This reverts commit 1f6c819e404e58c9a36712ff7d4b6e50069c852b.

The Drupal version in `andrewberry/drupal_tests` should be updated to 8.6.7 now.