### PR TITLE
This adds a general purpose team access check.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,9 @@ update_dependencies: &update_dependencies
     - run:
         working_directory: /var/www/html
         command: |
-          sudo sed -i 's/^zend_extension/;zend_extension/g' /usr/local/etc/php/conf.d/xdebug.ini
           cp ./modules/apigee_m10n/.circleci/RoboFile.php /var/www/html
           cp ./modules/apigee_m10n/.circleci/update-dependencies.sh /var/www/html
           ./update-dependencies.sh apigee_m10n
-          wget -q -O - https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch | patch -p1
 
     - save_cache: *save_cache
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
             "apigee/apigee-client-php": {
                 "Fix company ID issue for subscriptions": "https://github.com/apigee/apigee-client-php/files/2847006/company-accepted-company-id-fix.patch.txt"
             },
+            "drupal/apigee_edge": {
+                "Adds team roles": "https://patch-diff.githubusercontent.com/raw/apigee/apigee-edge-drupal/pull/138.patch"
+            },
             "drupal/core": {
                 "`EntityViewBuilder::getBuildDefaults()` doesn't check for `RevisionableInterface`.": "https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch"
             }

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.services.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.services.yml
@@ -1,3 +1,9 @@
 services:
   apigee_m10n.teams:
     class: Drupal\apigee_m10n_teams\MonetizationTeams
+
+  apigee_m10n_teams.access_check.team_permission:
+    class: Drupal\apigee_m10n_teams\Access\TeamPermissionAccessCheck
+    arguments: ['@apigee_edge_teams.team_permissions']
+    tags:
+      - { name: access_check, applies_to: _team_permission }

--- a/modules/apigee_m10n_teams/src/Access/TeamPermissionAccessCheck.php
+++ b/modules/apigee_m10n_teams/src/Access/TeamPermissionAccessCheck.php
@@ -63,14 +63,15 @@ class TeamPermissionAccessCheck implements AccessInterface {
    *   The access result.
    */
   public function access(Route $route, TeamInterface $team, AccountInterface $account) {
-    $permission = $route->getRequirement('_permission');
-
-    if ($permission === NULL) {
-      return AccessResult::neutral();
-    }
     // Team administrators have all access.
     if ($account->hasPermission('administer team')) {
       return AccessResult::allowed();
+    }
+
+    // Make sure the team permission is set in the route.
+    $permission = $route->getRequirement('_team_permission');
+    if ($permission === NULL) {
+      return AccessResult::neutral();
     }
 
     // Allow to conjunct the permissions with OR ('+') or AND (',').

--- a/modules/apigee_m10n_teams/src/Access/TeamPermissionAccessCheck.php
+++ b/modules/apigee_m10n_teams/src/Access/TeamPermissionAccessCheck.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Access;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_edge_teams\TeamPermissionHandlerInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultReasonInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Access check for team permission.
+ */
+class TeamPermissionAccessCheck implements AccessInterface {
+
+  /**
+   * The team permission handler.
+   *
+   * @var \Drupal\apigee_edge_teams\TeamPermissionHandlerInterface
+   */
+  private $teamPermissionHandler;
+
+  /**
+   * ManageTeamMembersAccess constructor.
+   *
+   * @param \Drupal\apigee_edge_teams\TeamPermissionHandlerInterface $team_permission_handler
+   *   The team permission handler.
+   */
+  public function __construct(TeamPermissionHandlerInterface $team_permission_handler) {
+    $this->teamPermissionHandler = $team_permission_handler;
+  }
+
+  /**
+   * Provides a generic access check for team permissions.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route.
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface $team
+   *   The Apigee Edge team.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(Route $route, TeamInterface $team, AccountInterface $account) {
+    $permission = $route->getRequirement('_permission');
+
+    if ($permission === NULL) {
+      return AccessResult::neutral();
+    }
+    // Team administrators have all access.
+    if ($account->hasPermission('administer team')) {
+      return AccessResult::allowed();
+    }
+
+    // Allow to conjunct the permissions with OR ('+') or AND (',').
+    $split = explode(',', $permission);
+    if (count($split) > 1) {
+      return $this->allowedIfHasTeamPermissions($team, $account, $split, 'AND');
+    }
+    else {
+      $split = explode('+', $permission);
+      return $this->allowedIfHasTeamPermissions($team, $account, $split, 'OR');
+    }
+  }
+
+  /**
+   * Creates an allowed access result if the team permissions are present.
+   *
+   * See: `\Drupal\Core\Access\AccessResult::allowedIfHasPermissions()`.
+   *
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface $team
+   *   The Apigee Edge team.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param array $permissions
+   *   An array of permissions.
+   * @param string $conjunction
+   *   (optional) 'AND' if all permissions are required, 'OR' in case just one.
+   *   Defaults to 'AND'.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   If the account has the permissions, isAllowed() will be TRUE, otherwise
+   *   isNeutral() will be TRUE.
+   */
+  protected function allowedIfHasTeamPermissions(TeamInterface $team, AccountInterface $account, array $permissions, $conjunction = 'AND') {
+    $access = FALSE;
+
+    if ($conjunction == 'AND' && !empty($permissions)) {
+      $access = TRUE;
+      foreach ($permissions as $permission) {
+        if (!$permission_access = $this->hasTeamPermission($team, $account, $permission)) {
+          $access = FALSE;
+          break;
+        }
+      }
+    }
+    else {
+      foreach ($permissions as $permission) {
+        if ($permission_access = $this->hasTeamPermission($team, $account, $permission)) {
+          $access = TRUE;
+          break;
+        }
+      }
+    }
+
+    $access_result = AccessResult::allowedIf($access)
+      ->addCacheContexts(empty($permissions) ? [] : ['team.permissions'])
+      ->addCacheableDependency($team)
+      ->addCacheableDependency($account);
+
+    if ($access_result instanceof AccessResultReasonInterface) {
+      if (count($permissions) === 1) {
+        $access_result->setReason("The '{$permission}' permission is required.");
+      }
+      elseif (count($permissions) > 1) {
+        $quote = function ($s) {
+          return "'$s'";
+        };
+        $access_result->setReason(sprintf("The following permissions are required: %s.", implode(" $conjunction ", array_map($quote, $permissions))));
+      }
+    }
+
+    return $access_result;
+  }
+
+  /**
+   * Checks that a developer has a given company permission.
+   *
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface $team
+   *   The Apigee Edge team.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $permission
+   *   The permission.
+   *
+   * @return bool
+   *   Whether or not the user has the team permission.
+   */
+  protected function hasTeamPermission(TeamInterface $team, AccountInterface $account, string $permission) {
+
+    return !$account->isAnonymous()
+      && ($permissions = $this->teamPermissionHandler->getDeveloperPermissionsByTeam($team, $account))
+      && in_array($permission, $permissions);
+  }
+
+}

--- a/modules/apigee_m10n_teams/tests/src/Kernel/TeamsEntityOverrideTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/TeamsEntityOverrideTest.php
@@ -39,6 +39,7 @@ class TeamsEntityOverrideTest extends KernelTestBase {
   public static $modules = [
     'key',
     'apigee_edge',
+    'apigee_edge_teams',
     'apigee_m10n',
     'apigee_m10n_teams',
   ];

--- a/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
@@ -112,11 +112,11 @@ class TeamPermissionAccessCheckUnitTest extends UnitTestCase {
    *
    * @dataProvider accessData
    */
-  public function testAccess($account_permissions, $route_permission, $expected) {
+  public function testAccess($account_permissions, $team_permission, $expected) {
     $checker = new TeamPermissionAccessCheck($this->getPermissionHandler($account_permissions));
 
     $route_mock = $this->prophesize(Route::class);
-    $route_mock->getRequirement('_permission')->willReturn($route_permission);
+    $route_mock->getRequirement('_team_permission')->willReturn($team_permission);
     $route = $route_mock->reveal();
     $result = $checker->access($route, $this->team, $this->account);
 
@@ -134,49 +134,49 @@ class TeamPermissionAccessCheckUnitTest extends UnitTestCase {
       // Account with no team permissions.
       [
         'account_permissions' => [],
-        'route_permission' => 'access foo',
+        'team_permission' => 'access foo',
         'expected' => AccessResultNeutral::class,
       ],
       // Account with single required permission.
       [
         'account_permissions' => ['access foo'],
-        'route_permission' => 'access foo',
+        'team_permission' => 'access foo',
         'expected' => AccessResultAllowed::class,
       ],
       // Account with one of two required permissions.
       [
         'account_permissions' => ['access foo'],
-        'route_permission' => 'access foo,access bar',
+        'team_permission' => 'access foo,access bar',
         'expected' => AccessResultNeutral::class,
       ],
       // Account with both of the required team permissions.
       [
         'account_permissions' => ['access foo', 'access bar'],
-        'route_permission' => 'access foo,access bar',
+        'team_permission' => 'access foo,access bar',
         'expected' => AccessResultAllowed::class,
       ],
       // Account with no matching permission.
       [
         'account_permissions' => [''],
-        'route_permission' => 'access foo+access bar',
+        'team_permission' => 'access foo+access bar',
         'expected' => AccessResultNeutral::class,
       ],
       // Account with the first matching permission.
       [
         'account_permissions' => ['access foo'],
-        'route_permission' => 'access foo+access bar',
+        'team_permission' => 'access foo+access bar',
         'expected' => AccessResultAllowed::class,
       ],
       // Account with the second matching permission.
       [
         'account_permissions' => ['access bar'],
-        'route_permission' => 'access foo+access bar',
+        'team_permission' => 'access foo+access bar',
         'expected' => AccessResultAllowed::class,
       ],
       // Failure to add a permission.
       [
         'account_permissions' => ['access bar'],
-        'route_permission' => NULL,
+        'team_permission' => NULL,
         'expected' => AccessResultNeutral::class,
       ],
     ];

--- a/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n_teams\Unit;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_edge_teams\TeamPermissionHandlerInterface;
+use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessCheck;
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Tests the team permission access checker.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_unit
+ * @group apigee_m10n_teams
+ * @group apigee_m10n_teams_unit
+ */
+class TeamPermissionAccessCheckUnitTest extends UnitTestCase {
+
+  /**
+   * The team.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $team;
+
+  /**
+   * The user account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Mock the team.
+    $team = $this->prophesize(TeamInterface::class);
+    $team->id()->willReturn('team-a');
+    $team->getCacheContexts()->willReturn([]);
+    $team->getCacheTags()->willReturn(['team:team-a']);
+    $team->getCacheMaxAge()->willReturn(-1);
+    $this->team = $team->reveal();
+
+    // Mock a user account.
+    $account = $this->prophesize(AccountInterface::class);
+    $account->getEmail()->willReturn('foo@example.com');
+    $account->isAnonymous()->willReturn(FALSE);
+    $account->hasPermission('administer team')->willReturn(FALSE);
+    $this->account = $account->reveal();
+
+    // Mock the cache context manager.
+    $cache_manager = $this->prophesize(CacheContextsManager::class);
+    $cache_manager->assertValidTokens(Argument::any())->willReturn(TRUE);
+    // Mock the container.
+    $container = $this->prophesize(ContainerInterface::class);
+    $container->get('cache_contexts_manager')->willReturn($cache_manager->reveal());
+
+    \Drupal::setContainer($container->reveal());
+  }
+
+  /**
+   * Tests the `access` callback with an admin user.
+   */
+  public function testAdminAccess() {
+    // Mock an admin account.
+    $account_mock = $this->prophesize(AccountInterface::class);
+    $account_mock->getEmail()->willReturn('admin@example.com');
+    $account_mock->isAnonymous()->willReturn(FALSE);
+    $account_mock->hasPermission('administer team')->willReturn(TRUE);
+    $account = $account_mock->reveal();
+
+    $checker = new TeamPermissionAccessCheck($this->getPermissionHandler([], NULL, $account));
+
+    $route_mock = $this->prophesize(Route::class);
+    $route_mock->getRequirement('_permission')->willReturn('access foo');
+    $route = $route_mock->reveal();
+    $result = $checker->access($route, $this->team, $account);
+
+    static::assertInstanceOf(AccessResultAllowed::class, $result);
+  }
+
+  /**
+   * Tests the `access` callback.
+   *
+   * @dataProvider accessData
+   */
+  public function testAccess($account_permissions, $route_permission, $expected) {
+    $checker = new TeamPermissionAccessCheck($this->getPermissionHandler($account_permissions));
+
+    $route_mock = $this->prophesize(Route::class);
+    $route_mock->getRequirement('_permission')->willReturn($route_permission);
+    $route = $route_mock->reveal();
+    $result = $checker->access($route, $this->team, $this->account);
+
+    static::assertInstanceOf($expected, $result);
+  }
+
+  /**
+   * Provides data for `::testAccess`.
+   *
+   * @return array
+   *   The data.
+   */
+  public function accessData() {
+    return [
+      // Account with no team permissions.
+      [
+        'account_permissions' => [],
+        'route_permission' => 'access foo',
+        'expected' => AccessResultNeutral::class,
+      ],
+      // Account with single required permission.
+      [
+        'account_permissions' => ['access foo'],
+        'route_permission' => 'access foo',
+        'expected' => AccessResultAllowed::class,
+      ],
+      // Account with one of two required permissions.
+      [
+        'account_permissions' => ['access foo'],
+        'route_permission' => 'access foo,access bar',
+        'expected' => AccessResultNeutral::class,
+      ],
+      // Account with both of the required team permissions.
+      [
+        'account_permissions' => ['access foo', 'access bar'],
+        'route_permission' => 'access foo,access bar',
+        'expected' => AccessResultAllowed::class,
+      ],
+      // Account with no matching permission.
+      [
+        'account_permissions' => [''],
+        'route_permission' => 'access foo+access bar',
+        'expected' => AccessResultNeutral::class,
+      ],
+      // Account with the first matching permission.
+      [
+        'account_permissions' => ['access foo'],
+        'route_permission' => 'access foo+access bar',
+        'expected' => AccessResultAllowed::class,
+      ],
+      // Account with the second matching permission.
+      [
+        'account_permissions' => ['access bar'],
+        'route_permission' => 'access foo+access bar',
+        'expected' => AccessResultAllowed::class,
+      ],
+    ];
+  }
+
+  /**
+   * Get's a mock permission handler.
+   *
+   * @param array $permissions
+   *   The permissions that should be returned for the team member.
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface|null $team
+   *   The Apigee Edge team.
+   * @param \Drupal\Core\Session\AccountInterface|null $account
+   *   The user account.
+   *
+   * @return \Drupal\apigee_edge_teams\TeamPermissionHandlerInterface
+   *   The mock.
+   */
+  private function getPermissionHandler($permissions, $team = NULL, $account = NULL) {
+    // Use the test team and account by default.
+    $team = $team ?? $this->team;
+    $account = $account ?? $this->account;
+    // Mock a permission handler.
+    $permission_handler = $this->prophesize(TeamPermissionHandlerInterface::class);
+    $permission_handler
+      ->getDeveloperPermissionsByTeam($team, $account)
+      ->willReturn($permissions);
+
+    return $permission_handler->reveal();
+  }
+
+}

--- a/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
@@ -173,6 +173,12 @@ class TeamPermissionAccessCheckUnitTest extends UnitTestCase {
         'route_permission' => 'access foo+access bar',
         'expected' => AccessResultAllowed::class,
       ],
+      // Failure to add a permission.
+      [
+        'account_permissions' => ['access bar'],
+        'route_permission' => NULL,
+        'expected' => AccessResultNeutral::class,
+      ],
     ];
   }
 


### PR DESCRIPTION
This add the patch that enables team roles. See: https://github.com/apigee/apigee-edge-drupal/pull/138

It also adds a general `_team_permission` access check you can use in routing files.

```
apigee_monetization_teams.billing:
...
  requirements:
    _team_permission: 'administer team'
```
