### PR TITLE
[DRUP-565] Add switcher route options to `apigee_m10n` provided routes.

### DIFF
--- a/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
@@ -7,6 +7,7 @@ apigee_monetization_teams.billing:
     _team_permission: 'view prepaid balance'
   options:
     _apigee_monetization_route: TRUE
+    _apigee_developer_route: apigee_monetization.billing
 
 entity.subscription.team_collection:
   path: '/teams/{team}/monetization/subscriptions'
@@ -18,6 +19,7 @@ entity.subscription.team_collection:
     _team_permission: 'view subscription'
   options:
     _apigee_monetization_route: TRUE
+    _apigee_developer_route: entity.subscription.developer_collection
 
 entity.rate_plan.team_subscribe:
   path: '/teams/{team}/monetization/package/{package}/plan/{rate_plan}/subscribe'
@@ -28,6 +30,7 @@ entity.rate_plan.team_subscribe:
     _entity_access: 'rate_plan.subscribe'
   options:
     _apigee_monetization_route: TRUE
+    _apigee_developer_route: entity.rate_plan.subscribe
 
 entity.subscription.team_unsubscribe_form:
   path: '/teams/{team}/monetization/subscription/{subscription}/unsubscribe'
@@ -52,6 +55,7 @@ apigee_monetization.team_packages:
     _team_permission: 'view package'
   options:
     _apigee_monetization_route: TRUE
+    _apigee_developer_route: apigee_monetization.packages
 
 apigee_m10n_teams.team_billing_details:
   path: '/teams/{team}/monetization/billing-details'
@@ -62,3 +66,4 @@ apigee_m10n_teams.team_billing_details:
     _team_permission: 'edit billing details'
   options:
     _apigee_monetization_route: TRUE
+    _apigee_developer_route: apigee_monetization.profile

--- a/modules/apigee_m10n_teams/src/Entity/Routing/MonetizationTeamsEntityRouteProvider.php
+++ b/modules/apigee_m10n_teams/src/Entity/Routing/MonetizationTeamsEntityRouteProvider.php
@@ -68,6 +68,14 @@ class MonetizationTeamsEntityRouteProvider extends MonetizationEntityRouteProvid
           $entity_type_id => ['type' => 'entity:' . $entity_type_id],
         ]);
 
+      // Set the corresponding route.
+      if ($entity_type->hasLinkTemplate('developer')) {
+        $route->setOption('_apigee_developer_route', "entity.{$entity_type_id}.developer");
+      }
+      elseif ($entity_type->hasLinkTemplate('canonical')) {
+        $route->setOption('_apigee_developer_route', "entity.{$entity_type_id}.canonical");
+      }
+
       // Entity types with serial IDs can specify this in their route
       // requirements, improving the matching process.
       if ($this->getEntityTypeIdKeyType($entity_type) === 'integer') {


### PR DESCRIPTION
Purchased plan ids are specific to the team so we cannot switch context for them.