### PR TITLE
[DRUP-688] Remove core patch and overriden methods for isDefaultRevision()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
     "prefer-stable": true,
     "extra": {
         "patches": {
-            "drupal/core": {
-                "`EntityViewBuilder::getBuildDefaults()` doesn't check for `RevisionableInterface`.": "https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch"
-            },
             "apigee/apigee-client-php": {
                 "The `keepOriginalStartDate` attribute is not always set on rate plan revisions.": "https://github.com/apigee/apigee-client-php/files/2998801/keep-original-start-date.patch.txt"
             }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "cweagans/composer-patches": "^1.6",
         "commerceguys/intl": "^1.0",
-        "drupal/apigee_edge": "^1.0-rc1"
+        "drupal/apigee_edge": "^1.0-rc3"
     },
     "require-dev": {
         "behat/mink-extension": "v2.2",

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -245,13 +245,6 @@ class Package extends FieldableEdgeEntityBase implements PackageInterface {
   /**
    * {@inheritdoc}
    */
-  public function isDefaultRevision($new_value = NULL) {
-    return TRUE;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   protected function drupalEntityId(): ?string {
     return $this->decorated->id();
   }

--- a/src/Entity/RatePlan.php
+++ b/src/Entity/RatePlan.php
@@ -170,13 +170,6 @@ class RatePlan extends FieldableEdgeEntityBase implements RatePlanInterface {
 
   /**
    * {@inheritdoc}
-   */
-  public function isDefaultRevision($new_value = NULL) {
-    return TRUE;
-  }
-
-  /**
-   * {@inheritdoc}
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    *   Thrown if the entity type doesn't exist.

--- a/src/Entity/Subscription.php
+++ b/src/Entity/Subscription.php
@@ -186,13 +186,6 @@ class Subscription extends FieldableEdgeEntityBase implements SubscriptionInterf
 
   /**
    * {@inheritdoc}
-   */
-  public function isDefaultRevision($new_value = NULL) {
-    return TRUE;
-  }
-
-  /**
-   * {@inheritdoc}
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException


### PR DESCRIPTION
If/when https://github.com/apigee/apigee-edge-drupal/pull/171 gets merged, this PR will remove the core patch, and remove duplicate overrriden methods of `isDefaultRevision()` from m10n entities (the method was moved to _EdgeEntityBase_).

Related to: https://github.com/apigee/apigee-m10n-drupal/issues/79 and https://www.drupal.org/project/drupal/issues/2951487.