### PR TITLE
[DRUP-698] Entity cache

### DIFF
--- a/apigee_m10n.services.yml
+++ b/apigee_m10n.services.yml
@@ -52,3 +52,9 @@ services:
     class: Drupal\apigee_m10n\Entity\Access\EntityDeveloperAccessCheck
     tags:
       - { name: access_check, applies_to: _entity_developer_access }
+
+  cache_context.url.developer:
+    class: Drupal\apigee_m10n\Cache\DeveloperCacheContext
+    arguments: ['@request_stack']
+    tags:
+      - { name: cache.context }

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.services.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.services.yml
@@ -12,3 +12,9 @@ services:
   apigee_m10n_teams.sdk_controller_factory:
     class: Drupal\apigee_m10n_teams\TeamSdkControllerFactory
     arguments: ['@apigee_edge.sdk_connector']
+
+  cache_context.url.team:
+    class: Drupal\apigee_m10n_teams\Cache\TeamCacheContext
+    arguments: ['@request_stack']
+    tags:
+      - { name: cache.context }

--- a/modules/apigee_m10n_teams/src/Cache/TeamCacheContext.php
+++ b/modules/apigee_m10n_teams/src/Cache/TeamCacheContext.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Cache;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Cache\Context\RequestStackCacheContextBase;
+
+/**
+ * Defines the TeamCacheContext service, for "per URL team" caching.
+ *
+ * Cache context ID: 'url.team'.
+ */
+class TeamCacheContext extends RequestStackCacheContextBase implements CacheContextInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getLabel() {
+    return t('Team');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext() {
+    $team = ($request = $this->requestStack->getCurrentRequest()) ? $request->get('team') : NULL;
+    return (string) ($team instanceof TeamInterface ? $team->id() : $team);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata() {
+    return new CacheableMetadata();
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/Entity/TeamsPackage.php
+++ b/modules/apigee_m10n_teams/src/Entity/TeamsPackage.php
@@ -60,4 +60,11 @@ class TeamsPackage extends Package implements TeamsPackageInterface {
       ->getAvailableApiPackagesByTeam($team_id);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return array_merge(['url.team'], parent::getCacheContexts());
+  }
+
 }

--- a/modules/apigee_m10n_teams/src/Entity/TeamsRatePlan.php
+++ b/modules/apigee_m10n_teams/src/Entity/TeamsRatePlan.php
@@ -63,4 +63,11 @@ class TeamsRatePlan extends RatePlan {
       : parent::getSubscribe();
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return array_merge(['url.team'], parent::getCacheContexts());
+  }
+
 }

--- a/modules/apigee_m10n_teams/tests/src/Unit/TeamCacheContextTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Unit/TeamCacheContextTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n_teams\Kernel;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_m10n_teams\Cache\TeamCacheContext;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests the testing the `url.team` cache context.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_unit
+ * @group apigee_m10n_teams
+ * @group apigee_m10n_teams_unit
+ */
+class TeamCacheContextTest extends UnitTestCase {
+
+  /**
+   * Tests the team cache context service.
+   */
+  public function testTeamCacheContext() {
+    // Test team context before param converters run.
+    $request = $this->prophesize(Request::class)
+      ->get('team')
+      ->willReturn('team-foo')
+      ->getObjectProphecy();
+
+    $request_stack = $this->prophesize(RequestStack::class)
+      ->getCurrentRequest()
+      ->willReturn($request)
+      ->getObjectProphecy();
+
+    $team_context = new TeamCacheContext($request_stack->reveal());
+
+    static::assertSame('Team', (string) TeamCacheContext::getLabel());
+    static::assertSame('team-foo', $team_context->getContext());
+
+    // Test team context before param converters run.
+    $user = $this->prophesize(TeamInterface::class)
+      ->id()
+      ->willReturn('team-foo')
+      ->getObjectProphecy();
+
+    $request = $this->prophesize(Request::class)
+      ->get('team')
+      ->willReturn($user->reveal())
+      ->getObjectProphecy();
+
+    $request_stack = $this->prophesize(RequestStack::class)
+      ->getCurrentRequest()
+      ->willReturn($request)
+      ->getObjectProphecy();
+
+    $team_context = new TeamCacheContext($request_stack->reveal());
+
+    static::assertSame('Team', (string) TeamCacheContext::getLabel());
+    static::assertSame('team-foo', $team_context->getContext());
+  }
+
+}
+
+// @codingStandardsIgnoreStart
+/**
+ * This is a hack since we don't want to load `bootstrap.inc` in a unit test.
+ */
+namespace Drupal\apigee_m10n_teams\Cache;
+
+use Drupal\Component\Render\MarkupInterface;
+use Prophecy\Prophet;
+
+/**
+ * {@inheritdoc}
+ */
+function t($string, array $args = [], array $options = []) {
+  $prophet = new Prophet();
+  return $prophet->prophesize(MarkupInterface::class)
+    ->__toString()
+    ->willReturn($string)
+    ->getObjectProphecy()
+    ->reveal();
+}
+// @codingStandardsIgnoreEnd

--- a/src/Cache/DeveloperCacheContext.php
+++ b/src/Cache/DeveloperCacheContext.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Cache;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Cache\Context\RequestStackCacheContextBase;
+use Drupal\user\UserInterface;
+
+/**
+ * Defines the DeveloperCacheContext service, for "per URL developer" caching.
+ *
+ * Cache context ID: 'url.developer'.
+ */
+class DeveloperCacheContext extends RequestStackCacheContextBase implements CacheContextInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getLabel() {
+    return t('Developer');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext() {
+    $user = ($request = $this->requestStack->getCurrentRequest()) ? $request->get('user') : NULL;
+    return (string) ($user instanceof UserInterface ? $user->id() : $user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata() {
+    return new CacheableMetadata();
+  }
+
+}

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -290,4 +290,11 @@ class Package extends FieldableEdgeEntityBase implements PackageInterface {
     return $user instanceof UserInterface ? $user->id() : $user;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return array_merge(['url.developer'], parent::getCacheContexts());
+  }
+
 }

--- a/src/Entity/RatePlan.php
+++ b/src/Entity/RatePlan.php
@@ -252,6 +252,13 @@ class RatePlan extends FieldableEdgeEntityBase implements RatePlanInterface {
   /**
    * {@inheritdoc}
    */
+  public function getCacheContexts() {
+    return array_merge(['url.developer'], parent::getCacheContexts());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function isAdvance(): bool {
     return $this->decorated->isAdvance();
   }

--- a/tests/src/Unit/DeveloperCacheContextTest.php
+++ b/tests/src/Unit/DeveloperCacheContextTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel;
+
+use Drupal\apigee_m10n\Cache\DeveloperCacheContext;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests the testing the `url.developer` cache context.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_unit
+ */
+class DeveloperCacheContextTest extends UnitTestCase {
+
+  /**
+   * Tests the developer cache context service.
+   */
+  public function testDeveloperCacheContext() {
+    // Test developer context before param converters run.
+    $request = $this->prophesize(Request::class)
+      ->get('user')
+      ->willReturn(2)
+      ->getObjectProphecy();
+
+    $request_stack = $this->prophesize(RequestStack::class)
+      ->getCurrentRequest()
+      ->willReturn($request)
+      ->getObjectProphecy();
+
+    $developer_context = new DeveloperCacheContext($request_stack->reveal());
+
+    static::assertSame('Developer', (string) DeveloperCacheContext::getLabel());
+    static::assertSame('2', $developer_context->getContext());
+
+    // Test developer context after param converters run.
+    $user = $this->prophesize(UserInterface::class)
+      ->id()
+      ->willReturn(2)
+      ->getObjectProphecy();
+
+    $request = $this->prophesize(Request::class)
+      ->get('user')
+      ->willReturn($user->reveal())
+      ->getObjectProphecy();
+
+    $request_stack = $this->prophesize(RequestStack::class)
+      ->getCurrentRequest()
+      ->willReturn($request)
+      ->getObjectProphecy();
+
+    $developer_context = new DeveloperCacheContext($request_stack->reveal());
+
+    static::assertSame('Developer', (string) DeveloperCacheContext::getLabel());
+    static::assertSame('2', $developer_context->getContext());
+  }
+
+}
+
+// @codingStandardsIgnoreStart
+/**
+ * This is a hack since we don't want to load `bootstrap.inc` in a unit test.
+ */
+namespace Drupal\apigee_m10n\Cache;
+
+use Drupal\Component\Render\MarkupInterface;
+use Prophecy\Prophet;
+
+/**
+ * {@inheritdoc}
+ */
+function t($string, array $args = [], array $options = []) {
+  $prophet = new Prophet();
+  return $prophet->prophesize(MarkupInterface::class)
+    ->__toString()
+    ->willReturn($string)
+    ->getObjectProphecy()
+    ->reveal();
+}
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
Adds cache context for developers and teams. Entity cache context is used by the entity view builder to build the cache keys.