### PR TITLE
[DRUP-639] Drupal 8.7.0 and changes in apigee edge.

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -408,16 +408,13 @@ class RoboFile extends \Robo\Tasks
         "*" => "dist"
       ];
 
-      // The drupal image contains ^8.6.7 but could be updated at any time.
-      // We need 8.6.13 to get past the twig issue so we require core instead of
-      // using the pre-installed (replaced) version. There are some caveats as
-      // we aren't using drupal scaffold at this point. This can be removed when
-      // the `andrewberry/drupal_tests` image is updated to 8.6.13.
-      // See: <https://github.com/deviantintegral/drupal_tests/issues/51>
-      // Require drupal core greater than 8.6.13 with strict dependencies.
-      $config->require->{"drupal/core"} = "~8.6.13";
-      $config->require->{"webflo/drupal-core-strict"} = "~8.6.13";
-      $config->{"require-dev"} = (object) ["webflo/drupal-core-require-dev" => "~8.6.13"];
+      // The drupal image contains Drupal core v8.6.x. A request has been made
+      // for an updated version.
+      // See: <https://github.com/deviantintegral/drupal_tests/issues/55>
+      // Require drupal core via composer.
+      $config->require->{"drupal/core"} = "~8.7.0";
+      $config->require->{"webflo/drupal-core-strict"} = "~8.7.0";
+      $config->{"require-dev"} = (object) ["webflo/drupal-core-require-dev" => "~8.7.0"];
       // If you require core, you must not replace it.
       unset($config->replace);
       // You can't merge from a package that is required.
@@ -427,7 +424,7 @@ class RoboFile extends \Robo\Tasks
         }
       }
       $config->extra->{"merge-plugin"}->include = array_values($config->extra->{"merge-plugin"}->include);
-      // TODO Revert this when `andrewberry/drupal_tests` is updated to ~8.6.13.
+      // TODO Revert this when `andrewberry/drupal_tests` is updated to ~8.7.0.
 
       // We need Drupal\commerce_store\StoreCreationTrait for AddCreditProductAdminTest.php
       $config->require->{"drupal/commerce"} = "~2.0";

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "cweagans/composer-patches": "^1.6",
         "commerceguys/intl": "^1.0",
-        "drupal/apigee_edge": "^1.0-rc3"
+        "drupal/apigee_edge": "^1.0-rc4"
     },
     "require-dev": {
         "behat/mink-extension": "v2.2",

--- a/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsKernelTestBase.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsKernelTestBase.php
@@ -26,15 +26,12 @@ use Drupal\apigee_edge_teams\Entity\TeamRole;
 use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
 use Drupal\Core\Session\UserSession;
 use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
-use Drupal\Tests\apigee_m10n_teams\Traits\AccountProphecyTrait;
 use Drupal\user\UserInterface;
 
 /**
  * The base class for Monetization teams kernel tests.
  */
 class MonetizationTeamsKernelTestBase extends MonetizationKernelTestBase {
-
-  use AccountProphecyTrait;
 
   public static $modules = [
     'key',

--- a/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsTest.php
@@ -32,7 +32,7 @@ use Drupal\apigee_m10n_teams\Plugin\Field\FieldFormatter\TeamSubscribeLinkFormat
 use Drupal\apigee_m10n_teams\Plugin\Field\FieldWidget\CompanyTermsAndConditionsWidget;
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Tests\apigee_m10n_teams\Traits\AccountProphecyTrait;
+use Drupal\Tests\apigee_m10n\Traits\AccountProphecyTrait;
 use Drupal\Tests\apigee_m10n_teams\Traits\TeamProphecyTrait;
 
 /**

--- a/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Unit/TeamPermissionAccessCheckUnitTest.php
@@ -25,7 +25,7 @@ use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessCheck;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Cache\Context\CacheContextsManager;
-use Drupal\Tests\apigee_m10n_teams\Traits\AccountProphecyTrait;
+use Drupal\Tests\apigee_m10n\Traits\AccountProphecyTrait;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
+++ b/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
@@ -64,8 +64,8 @@ class TestEnvironmentVariablesKeyProvider extends EnvironmentVariablesKeyProvide
   /**
    * {@inheritdoc}
    */
-  public function getKeyValue(KeyInterface $key) {
-    $key_value = parent::getKeyValue($key);
+  public function realGetKeyValue(KeyInterface $key) {
+    $key_value = parent::realGetKeyValue($key);
 
     // If the key_value is empty during a request callback get credentials from
     // state.

--- a/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
+++ b/tests/modules/apigee_m10n_test/src/Plugin/KeyProvider/TestEnvironmentVariablesKeyProvider.php
@@ -64,15 +64,18 @@ class TestEnvironmentVariablesKeyProvider extends EnvironmentVariablesKeyProvide
   /**
    * {@inheritdoc}
    */
-  public function realGetKeyValue(KeyInterface $key) {
-    $key_value = parent::realGetKeyValue($key);
-
+  public function checkRequirements(KeyInterface $key): void {
     // If the key_value is empty during a request callback get credentials from
     // state.
-    $key_value = (!empty($key_value) && $key_value !== '{}') ? $key_value
-      : $this->state->get(static::KEY_VALUE_STATE_ID);
+    $values = $this->state->get(static::KEY_VALUE_STATE_ID);
 
-    return $key_value;
+    foreach ($values as $env_name => $value) {
+      if (!getenv($env_name)) {
+        putenv("{$env_name}={$value}");
+      }
+    }
+
+    parent::checkRequirements($key);
   }
 
 }

--- a/tests/src/Kernel/Access/AccessKernelTest.php
+++ b/tests/src/Kernel/Access/AccessKernelTest.php
@@ -107,6 +107,7 @@ class AccessKernelTest extends MonetizationKernelTestBase {
     $this->package = $this->createPackage();
     $this->rate_plan = $this->createPackageRatePlan($this->package);
 
+    $this->prophesizeCurrentUser([]);
   }
 
   /**

--- a/tests/src/Traits/AccountProphecyTrait.php
+++ b/tests/src/Traits/AccountProphecyTrait.php
@@ -17,13 +17,13 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-namespace Drupal\Tests\apigee_m10n_teams\Traits;
+namespace Drupal\Tests\apigee_m10n\Traits;
 
 use Drupal\Core\Session\AccountProxyInterface;
 use Prophecy\Argument;
 
 /**
- * Tests the team permission access checker.
+ * Trait to prophesize an account.
  */
 trait AccountProphecyTrait {
 

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -125,8 +125,17 @@ trait ApigeeMonetizationTestTrait {
     ]);
 
     $key->save();
+
+    // Collect credentials from environment variables.
+    $fields = [];
+    foreach (array_keys($key->getKeyType()->getPluginDefinition()['multivalue']['fields']) as $field) {
+      $id = 'APIGEE_EDGE_' . strtoupper($field);
+      if ($value = getenv($id)) {
+        $fields[$id] = $value;
+      }
+    }
     // Make sure the credentials persists for functional tests.
-    \Drupal::state()->set(TestEnvironmentVariablesKeyProvider::KEY_VALUE_STATE_ID, $key->getKeyValue());
+    \Drupal::state()->set(TestEnvironmentVariablesKeyProvider::KEY_VALUE_STATE_ID, $fields);
 
     $this->config('apigee_edge.auth')
       ->set('active_key', 'apigee_m10n_test_auth')

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -38,7 +38,7 @@ use Drupal\apigee_m10n\Entity\SubscriptionInterface;
 use Drupal\apigee_m10n\EnvironmentVariable;
 use Drupal\apigee_m10n_test\Plugin\KeyProvider\TestEnvironmentVariablesKeyProvider;
 use Drupal\key\Entity\Key;
-use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeTestTrait;
+use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeFunctionalTestTrait;
 use Drupal\Tests\apigee_m10n_teams\Traits\AccountProphecyTrait;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
@@ -49,8 +49,7 @@ use Drupal\user\UserInterface;
 trait ApigeeMonetizationTestTrait {
 
   use AccountProphecyTrait;
-  use ApigeeEdgeTestTrait {
-    setUp as edgeSetup;
+  use ApigeeEdgeFunctionalTestTrait {
     createAccount as edgeCreateAccount;
   }
 
@@ -138,7 +137,7 @@ trait ApigeeMonetizationTestTrait {
   /**
    * Create an account.
    *
-   * We override this function from `ApigeeEdgeTestTrait` so we can queue the
+   * We override this function from `ApigeeEdgeFunctionalTestTrait` so we can queue the
    * appropriate response upon account creation.
    *
    * {@inheritdoc}

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -39,7 +39,6 @@ use Drupal\apigee_m10n\EnvironmentVariable;
 use Drupal\apigee_m10n_test\Plugin\KeyProvider\TestEnvironmentVariablesKeyProvider;
 use Drupal\key\Entity\Key;
 use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeFunctionalTestTrait;
-use Drupal\Tests\apigee_m10n_teams\Traits\AccountProphecyTrait;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 


### PR DESCRIPTION
Once there is an 8.7.0 compatible release of the `apigee_edge` module, this module can be updated to require the new release.
