### PR TITLE
[DRUP-725] Remove apigee-client-php patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,5 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "extra": {
-        "patches": {
-            "apigee/apigee-client-php": {
-                "The `keepOriginalStartDate` attribute is not always set on rate plan revisions.": "https://github.com/apigee/apigee-client-php/files/2998801/keep-original-start-date.patch.txt"
-            }
-        }
-    }
+    "prefer-stable": true
 }


### PR DESCRIPTION
Now that we have a new release for apigee-client-php and apigee-edge, we can remove the patch for it. https://github.com/apigee/apigee-client-php/releases/tag/2.0.2