### PR TITLE
[#114] Group the "Purchased plans" into 2 tables: Active and Future Plans, Canceled and Expired Plans

### DIFF
--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -254,9 +254,11 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
     $subscriptions = [
       SubscriptionInterface::STATUS_ACTIVE => [
         'title' => $this->t('Active and Future Plans'),
+        'entities' => [],
       ],
       SubscriptionInterface::STATUS_ENDED => [
         'title' => $this->t('Cancelled and Expired Plans'),
+        'entities' => [],
       ],
     ];
 
@@ -282,16 +284,18 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
         '#header' => $this->buildHeader(),
         '#title' => $subscription['title'],
         '#rows' => [],
-        '#empty' => $this->t('There are no @label yet.', ['@label' => $this->entityType->getPluralLabel()]),
+        '#empty' => $this->t('There are no @label yet.', ['@label' => strtolower($this->entityType->getPluralLabel())]),
         '#cache' => [
           'contexts' => $this->entityType->getListCacheContexts(),
           'tags' => $this->entityType->getListCacheTags(),
         ],
       ];
 
-      foreach ($subscription['entities'] as $entity) {
-        if ($row = $this->buildRow($entity)) {
-          $build[$key]['table']['#rows'][$entity->id()] = $row;
+      if (count($subscription['entities'])) {
+        foreach ($subscription['entities'] as $entity) {
+          if ($row = $this->buildRow($entity)) {
+            $build[$key]['table']['#rows'][$entity->id()] = $row;
+          }
         }
       }
 

--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -138,20 +138,14 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
   public function buildHeader() {
     return [
       'plan' => [
-        'data' => $this->t('Plan Name'),
+        'data' => $this->t('Rate plan'),
         'class' => ['rate-plan-name'],
         'field' => 'plan',
       ],
-      'package' => [
-        'data'  => $this->t('Package'),
-        'field' => 'package',
-        'class' => ['package-name'],
-        'sort'  => 'desc',
-      ],
-      'products' => [
-        'data' => $this->t('Products'),
-        'class' => ['products'],
-        'field' => 'products',
+      'status' => [
+        'data' => $this->t('Status'),
+        'field' => 'status',
+        'class' => ['field-status'],
       ],
       'start_date' => [
         'data' => $this->t('Start Date'),
@@ -162,21 +156,6 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
         'data' => $this->t('End Date'),
         'class' => ['subscription-end-date'],
         'field' => 'end_date',
-      ],
-      'plan_end_date' => [
-        'data' => $this->t('Plan End Date'),
-        'class' => ['rate-plan-end-date'],
-        'field' => 'plan_end_date',
-      ],
-      'renewal_date' => [
-        'data' => $this->t('Renewal Date'),
-        'class' => ['subscription-renewal-date'],
-        'field' => 'renewal_date',
-      ],
-      'status' => [
-        'data' => $this->t('Status'),
-        'field' => 'status',
-        'class' => ['field-status'],
       ],
       'operations' => [
         'data' => $this->t('Actions'),
@@ -190,11 +169,6 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
   public function buildRow(EntityInterface $entity) {
     /** @var \Drupal\apigee_m10n\Entity\SubscriptionInterface $entity */
     $rate_plan = $entity->getRatePlan();
-
-    // Concatenate all of the product names.
-    $products = implode(', ', array_map(function ($product) {
-      return $product->getDisplayName();
-    }, $rate_plan->getPackage()->getApiProducts()));
 
     $date_display_settings = [
       'label' => 'hidden',
@@ -210,13 +184,9 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
           'data' => Link::fromTextAndUrl($rate_plan->getDisplayName(), $this->ratePlanUrl($entity)),
           'class' => ['rate-plan-name'],
         ],
-        'package' => [
-          'data' => $rate_plan->getPackage()->getDisplayName(),
-          'class' => ['package-name'],
-        ],
-        'products' => [
-          'data' => $products,
-          'class' => ['products'],
+        'status' => [
+          'data' => $this->t('@status', ['@status' => $entity->getSubscriptionStatus()]),
+          'class' => ['field-status'],
         ],
         'start_date' => [
           'data' => $entity->get('startDate')->view($date_display_settings),
@@ -225,18 +195,6 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
         'end_date' => [
           'data' => $entity->getEndDate() ? $entity->get('endDate')->view($date_display_settings) : NULL,
           'class' => ['subscription-end-date'],
-        ],
-        'plan_end_date' => [
-          'data' => $rate_plan->getEndDate() ? $entity->get('endDate')->view($date_display_settings) : NULL,
-          'class' => ['rate-plan-end-date'],
-        ],
-        'renewal_date' => [
-          'data' => $entity->getRenewalDate() ? $entity->get('renewalDate')->view($date_display_settings) : NULL,
-          'class' => ['subscription-renewal-date'],
-        ],
-        'status' => [
-          'data' => $this->t('@status', ['@status' => $entity->getSubscriptionStatus()]),
-          'class' => ['field-status'],
         ],
         'operations'    => ['data' => $this->buildOperations($entity)],
       ],

--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -276,7 +276,7 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
         '#value' => $subscription['title'],
         '#tag' => 'h3',
       ];
-      
+
       $build[$key]['table'] = [
         '#type' => 'table',
         '#header' => $this->buildHeader(),

--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -30,7 +30,6 @@ use Drupal\Core\Link;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Url;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -211,15 +210,18 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
    */
   public function render() {
     $build = [];
+    $label = $this->entityType->getPluralLabel();
 
     // Group the subscriptions by status.
     $subscriptions = [
       SubscriptionInterface::STATUS_ACTIVE => [
-        'title' => $this->t('Active and Future Plans'),
+        'title' => $this->t('Active and Future @label', ['@label' => $label]),
+        'empty' => $this->t('No active or future @label.', ['@label' => strtolower($label)]),
         'entities' => [],
       ],
       SubscriptionInterface::STATUS_ENDED => [
-        'title' => $this->t('Cancelled and Expired Plans'),
+        'title' => $this->t('Cancelled and Expired @label', ['@label' => $label]),
+        'empty' => $this->t('No cancelled or expired @label.', ['@label' => strtolower($label)]),
         'entities' => [],
       ],
     ];
@@ -246,7 +248,7 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
         '#header' => $this->buildHeader(),
         '#title' => $subscription['title'],
         '#rows' => [],
-        '#empty' => $this->t('There are no @label yet.', ['@label' => strtolower($this->entityType->getPluralLabel())]),
+        '#empty' => $subscription['empty'],
         '#cache' => [
           'contexts' => $this->entityType->getListCacheContexts(),
           'tags' => $this->entityType->getListCacheTags(),

--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -139,13 +139,13 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
     return [
       'plan' => [
         'data' => $this->t('Rate plan'),
-        'class' => ['rate-plan-name'],
+        'class' => ['subscription-rate-plan'],
         'field' => 'plan',
       ],
       'status' => [
         'data' => $this->t('Status'),
         'field' => 'status',
-        'class' => ['field-status'],
+        'class' => ['subscription-status'],
       ],
       'start_date' => [
         'data' => $this->t('Start Date'),
@@ -182,7 +182,7 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
       'data' => [
         'plan' => [
           'data' => Link::fromTextAndUrl($rate_plan->getDisplayName(), $this->ratePlanUrl($entity)),
-          'class' => ['rate-plan-name'],
+          'class' => ['subscription-rate-plan'],
         ],
         'status' => [
           'data' => [
@@ -190,7 +190,7 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
             '#template' => '<span class="status status--{{ status|clean_class }}">{{ status }}</span>',
             '#context' => ['status' => $this->t('@status', ['@status' => $entity->getSubscriptionStatus()])],
           ],
-          'class' => ['field-status'],
+          'class' => ['subscription-status'],
         ],
         'start_date' => [
           'data' => $entity->get('startDate')->view($date_display_settings),

--- a/src/Entity/ListBuilder/SubscriptionListBuilder.php
+++ b/src/Entity/ListBuilder/SubscriptionListBuilder.php
@@ -185,7 +185,11 @@ abstract class SubscriptionListBuilder extends EntityListBuilder implements Cont
           'class' => ['rate-plan-name'],
         ],
         'status' => [
-          'data' => $this->t('@status', ['@status' => $entity->getSubscriptionStatus()]),
+          'data' => [
+            '#type' => 'inline_template',
+            '#template' => '<span class="status status--{{ status|clean_class }}">{{ status }}</span>',
+            '#context' => ['status' => $this->t('@status', ['@status' => $entity->getSubscriptionStatus()])],
+          ],
           'class' => ['field-status'],
         ],
         'start_date' => [

--- a/tests/src/Functional/SubscriptionListTest.php
+++ b/tests/src/Functional/SubscriptionListTest.php
@@ -77,8 +77,8 @@ class SubscriptionListTest extends MonetizationFunctionalTestBase {
     $this->assertSession()->responseNotContains('Connection error');
 
     // Checking my subscriptions table columns.
-    $this->assertCssElementText('.subscription-row:nth-child(1) td.field-status', 'Active');
-    $this->assertCssElementText('.subscription-row:nth-child(1) td.rate-plan-name', $rate_plan->getDisplayName());
+    $this->assertCssElementText('.subscription-row:nth-child(1) td.subscription-status', 'Active');
+    $this->assertCssElementText('.subscription-row:nth-child(1) td.subscription-rate-plan', $rate_plan->getDisplayName());
     $this->assertCssElementText('.subscription-row:nth-child(1) td.subscription-start-date', $subscription->getStartDate()->format('m/d/Y'));
     static::assertSame($this->cssSelect('.subscription-row:nth-child(1) td.subscription-end-date')[0]->getText(), '');
 

--- a/tests/src/Functional/SubscriptionListTest.php
+++ b/tests/src/Functional/SubscriptionListTest.php
@@ -78,8 +78,6 @@ class SubscriptionListTest extends MonetizationFunctionalTestBase {
 
     // Checking my subscriptions table columns.
     $this->assertCssElementText('.subscription-row:nth-child(1) td.field-status', 'Active');
-    $this->assertCssElementText('.subscription-row:nth-child(1) td.package-name', $rate_plan->getPackage()->getDisplayName());
-    $this->assertCssElementContains('.subscription-row:nth-child(1) td.products', $rate_plan->getPackage()->getApiProducts()[0]->getDisplayName());
     $this->assertCssElementText('.subscription-row:nth-child(1) td.rate-plan-name', $rate_plan->getDisplayName());
     $this->assertCssElementText('.subscription-row:nth-child(1) td.subscription-start-date', $subscription->getStartDate()->format('m/d/Y'));
     static::assertSame($this->cssSelect('.subscription-row:nth-child(1) td.subscription-end-date')[0]->getText(), '');

--- a/tests/src/Kernel/Controller/PackageControllerKernelTest.php
+++ b/tests/src/Kernel/Controller/PackageControllerKernelTest.php
@@ -20,6 +20,7 @@
 namespace Drupal\Tests\apigee_m10n\Kernel\Controller;
 
 use Drupal\apigee_m10n\Controller\PackagesController;
+use Drupal\Core\Database\Database;
 use Drupal\Core\Url;
 use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
 use Drupal\user\Entity\User;
@@ -75,8 +76,20 @@ class PackageControllerKernelTest extends MonetizationKernelTestBase {
         'status_code' => 201,
       ],
     ]);
-    // Install user 0 and user 1.
-    \user_install();
+    // Install user 0 and user 1. Workaround because or `user_install()` errors.
+    User::create([
+      'uid' => 0,
+      'status' => 0,
+      'name' => '',
+      'mail' => 'prevent-apigee_edge_user_presave-error',
+    ])->save();
+    Database::getConnection()->update('users_field_data')->fields(['mail' => NULL])->condition('uid', 0)->execute();
+    User::create([
+      'uid' => 1,
+      'name' => 'placeholder-for-uid-1',
+      'mail' => 'placeholder-for-uid-1',
+      'status' => TRUE,
+    ])->save();
     $this->warmSubscriptionsCache(User::load(1));
 
     $this->developer = $this->createAccount([


### PR DESCRIPTION
![Purchased_plans___Drupal_8_m10n](https://user-images.githubusercontent.com/124599/59053235-fbf8a780-88a1-11e9-98bd-f8688ca329ac.jpg)
