### PR TITLE
[Fixes #65] Require the bcmath php extensions

### DIFF
--- a/apigee_m10n.install
+++ b/apigee_m10n.install
@@ -53,6 +53,16 @@ function apigee_m10n_requirements($phase) {
     }
   }
 
+  if ($phase == 'install' || $phase == 'runtime') {
+    if (!extension_loaded('bcmath')) {
+      $requirements['apigee_monetization_bcmath'] = [
+        'title' => t('BC Math'),
+        'description' => t('Apigee Monetization requires the BC Math PHP extension in order to format prices.'),
+        'severity' => REQUIREMENT_ERROR,
+      ];
+    }
+  }
+
   return $requirements;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "Apigee Edge Monetization for Drupal",
     "require": {
         "php": ">=7.1",
+        "ext-bcmath": "*",
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
         "drupal/apigee_edge": "~1.0",


### PR DESCRIPTION
since the formatters require `commerceguys/intl`.