### PR TITLE
[#150] Show "Add credit" button on balances even if no balances available

### DIFF
--- a/modules/apigee_m10n_add_credit/src/AddCreditService.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditService.php
@@ -317,6 +317,27 @@ class AddCreditService implements AddCreditServiceInterface {
    * {@inheritdoc}
    */
   public function apigeeM10nPrepaidBalanceListAlter(array &$build, EntityInterface $entity) {
+
+    // Show links to "Add credit" even if no current balances in all or
+    // some currencies.
+    $currencies = Drupal::service('commerce_price.currency_repository')->getAll();
+    foreach ($currencies as $currency) {
+      $currency_id = strtolower($currency->getCurrencyCode());
+      if (empty($build['table']['#rows'][$currency_id])) {
+        $build['table']['#rows'][$currency_id] = [
+          'class' => ["apigee-balance-row-{$currency_id}"],
+          'data' => [
+            'currency' => $currency->getCurrencyCode(),
+            'previous_balance' => $this->t('There is no balance available.'),
+            'credit' => '',
+            'usage' => '',
+            'tax' => '',
+            'current_balance' => '',
+          ],
+        ];
+      }
+    }
+
     // TODO: This can be move to entity operations when/if prepaid balance are
     // made into entities.
     if ((count($build['table']['#rows']))) {


### PR DESCRIPTION
Added the "add credit" button for all currencies enabled. 
Example for when no balance available for any currency:
![Screenshot_2019-07-03 Prepaid balance Apigee Developer Portal Kickstart M10N(2)](https://user-images.githubusercontent.com/4062676/60618307-74686080-9d9b-11e9-8132-b220d81aa837.png)

Example for when a balance is available for only some currencies:
![Screenshot_2019-07-03 Prepaid balance Apigee Developer Portal Kickstart M10N(1)](https://user-images.githubusercontent.com/4062676/60618311-76322400-9d9b-11e9-9b72-e34c3ab00137.png)