### PR TITLE
[Fixes #118] Move the monetization admin menu to `admin/config/apigee…

### DIFF
--- a/apigee_m10n.links.menu.yml
+++ b/apigee_m10n.links.menu.yml
@@ -1,6 +1,6 @@
 system.admin_apigee_m10n:
-  title: 'Monetization'
-  parent: system.admin_config_edge
+  title: 'Apigee monetization'
+  parent: system.admin_config
   route_name: apigee_m10n.settings
 
 entity.package.collection:

--- a/apigee_m10n.routing.yml
+++ b/apigee_m10n.routing.yml
@@ -1,5 +1,5 @@
 apigee_m10n.settings:
-  path: /admin/config/apigee-edge/monetization
+  path: /admin/config/apigee-monetization
   defaults:
     _controller: \Drupal\system\Controller\SystemController::systemAdminMenuBlockPage
     _title: Monetization
@@ -11,7 +11,7 @@ apigee_m10n.settings:
 
 # This route is required for field UI routes to be attached to.
 apigee_m10n.settings.rate_plan:
-  path: /admin/config/apigee-edge/monetization/rate-plan
+  path: /admin/config/apigee-monetization/rate-plan
   defaults:
     _form: \Drupal\apigee_m10n\Form\RatePlanConfigForm
     _title: Rate Plans
@@ -21,7 +21,7 @@ apigee_m10n.settings.rate_plan:
     _apigee_monetization_route: TRUE
 
 apigee_m10n.settings.package:
-  path: /admin/config/apigee-edge/monetization/package
+  path: /admin/config/apigee-monetization/package
   defaults:
     _controller: \Drupal\system\Controller\SystemController::systemAdminMenuBlockPage
     _title: Package settings
@@ -31,7 +31,7 @@ apigee_m10n.settings.package:
     _apigee_monetization_route: TRUE
 
 apigee_m10n.settings.prepaid_balance:
-  path: /admin/config/apigee-edge/monetization/prepaid-balance
+  path: /admin/config/apigee-monetization/prepaid-balance
   defaults:
     _form: \Drupal\apigee_m10n\Form\PrepaidBalanceConfigForm
     _title: Prepaid balance
@@ -41,7 +41,7 @@ apigee_m10n.settings.prepaid_balance:
     _apigee_monetization_route: TRUE
 
 apigee_m10n.settings.purchased_plan:
-  path: /admin/config/apigee-edge/monetization/purchased-plan-settings
+  path: /admin/config/apigee-monetization/purchased-plan-settings
   defaults:
     _controller: \Drupal\system\Controller\SystemController::systemAdminMenuBlockPage
     _title: Rate plan purchase settings
@@ -51,7 +51,7 @@ apigee_m10n.settings.purchased_plan:
     _apigee_monetization_route: TRUE
 
 entity.package.collection:
-  path: /admin/config/apigee-edge/monetization/package/list
+  path: /admin/config/apigee-monetization/package/list
   defaults:
     _entity_list: package
     _title: Packages


### PR DESCRIPTION
…-monetization`.