### PR TITLE
[#162] Allow access to team specific rate plan and team category rate plans

### DIFF
--- a/apigee_m10n.module
+++ b/apigee_m10n.module
@@ -22,6 +22,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\apigee_m10n\Entity\RatePlanInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -100,4 +101,13 @@ function apigee_m10n_preprocess_field(&$variables) {
   if ($variables['field_name'] === 'futurePlanLinks') {
     $variables['#attached']['library'][] = 'apigee_m10n/rate_plan.future_links_field';
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_create_access().
+ */
+function apigee_m10n_purchased_plan_create_access(AccountInterface $account, array $context, $entity_bundle) {
+  // Make sure rate plan context exists.
+  $access = AccessResult::allowedIf(isset($context['rate_plan']) && $context['rate_plan'] instanceof RatePlanInterface);
+  return $access->andIf($context['rate_plan']->access('purchase', $account, TRUE));
 }

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.module
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.module
@@ -58,13 +58,6 @@ function apigee_m10n_teams_rate_plan_access(EntityInterface $entity, $operation,
 }
 
 /**
- * Implements hook_ENTITY_TYPE_create_access().
- */
-function apigee_m10n_teams_purchased_plan_create_access(AccountInterface $account, array $context, $entity_bundle) {
-  return Drupal::service('apigee_m10n.teams')->purchasedPlanCreateAccess($account, $context, $entity_bundle);
-}
-
-/**
  * Implements hook_ENTITY_TYPE_access().
  */
 function apigee_m10n_teams_product_bundle_access(EntityInterface $entity, $operation, AccountInterface $account) {

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.module
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.module
@@ -53,13 +53,6 @@ function apigee_m10n_teams_purchased_plan_access(EntityInterface $entity, $opera
 /**
  * Implements hook_ENTITY_TYPE_access().
  */
-function apigee_m10n_teams_rate_plan_access(EntityInterface $entity, $operation, AccountInterface $account) {
-  return Drupal::service('apigee_m10n.teams')->ratePlanAccess($entity, $operation, $account);
-}
-
-/**
- * Implements hook_ENTITY_TYPE_access().
- */
 function apigee_m10n_teams_product_bundle_access(EntityInterface $entity, $operation, AccountInterface $account) {
   return Drupal::service('apigee_m10n.teams')->entityAccess($entity, $operation, $account);
 }

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.team_permissions.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.team_permissions.yml
@@ -1,5 +1,5 @@
 permission_providers:
-  - Drupal\apigee_m10n_teams\Entity\Access\MonetizationTeamPermissionsProvider
+  - Drupal\apigee_m10n_teams\Entity\Permissions\MonetizationTeamPermissionsProvider
 
 view prepaid balance:
   title: 'View prepaid balance'

--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Entity\Access;
+
+use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
+use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
+use Drupal\apigee_edge_teams\Entity\Team;
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_m10n\Entity\Access\RatePlanAccessControlHandler;
+use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface;
+use Drupal\apigee_m10n_teams\MonetizationTeamsInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access controller for the rate_plan entity.
+ */
+class TeamRatePlanAccessControlHandler extends RatePlanAccessControlHandler {
+
+
+  /**
+   * The teams monetization service.
+   *
+   * @var \Drupal\apigee_m10n_teams\MonetizationTeamsInterface
+   */
+  protected $teamMonitization;
+
+  /**
+   * The team access service.
+   *
+   * @var \Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface
+   */
+  protected $teamAccess;
+
+  /**
+   * Constructs an access control handler instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\apigee_m10n_teams\MonetizationTeamsInterface $team_monetization
+   *   Teams monetization factory.
+   * @param \Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface $team_access
+   *   The team access service.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entityTypeManager, MonetizationTeamsInterface $team_monetization, TeamPermissionAccessInterface $team_access) {
+    parent::__construct($entity_type, $entityTypeManager);
+    $this->teamMonitization = $team_monetization;
+    $this->teamAccess = $team_access;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager'),
+      $container->get('apigee_m10n.teams'),
+      $container->get('apigee_m10n_teams.access_check.team_permission')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    // Get the SDK rate plan.
+    /** @var \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface $sdk_rate_plan */
+    $sdk_rate_plan = $entity->decorated();
+    if ($sdk_rate_plan instanceof CompanyRatePlanInterface) {
+      $company = $entity->getCompany();
+      $team = $company instanceof CompanyInterface ? Team::load($company->id()) : NULL;
+      return $team
+        ? $this->teamAccess->allowedIfHasTeamPermissions($team, $account, ["{$operation} rate_plan"])
+        : AccessResult::forbidden('Unable to load the specified team of the team rate plan.');
+    }
+    elseif ($sdk_rate_plan instanceof StandardRatePlanInterface && $this->teamMonitization->currentTeam()) {
+      return $this->teamMonitization->entityAccess($entity, $operation, $account);
+    }
+    // TODO: handle `CompanyCategoryRatePlan` rate plans if they exist.
+    return parent::checkAccess($entity, $operation, $account);
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
@@ -95,7 +95,7 @@ class TeamRatePlanAccessControlHandler extends RatePlanAccessControlHandler {
 
     // Test access to CompanyRatePlanInterface.
     if ($sdk_rate_plan instanceof CompanyRatePlanInterface) {
-      $company = $entity->getCompany();
+      $company = $sdk_rate_plan->getCompany();
       $team = $company instanceof CompanyInterface ? Team::load($company->id()) : NULL;
       return $team
         ? $this->teamAccess->allowedIfHasTeamPermissions($team, $account, ["{$operation} rate_plan"])
@@ -105,7 +105,7 @@ class TeamRatePlanAccessControlHandler extends RatePlanAccessControlHandler {
     // Test access to a DeveloperCategoryRatePlanInterface, where the team has
     // the required category.
     elseif ($sdk_rate_plan instanceof DeveloperCategoryRatePlanInterface) {
-     if (($category = $sdk_rate_plan->getDeveloperCategory()) && ($team = $this->teamMonitization->currentTeam())) {
+      if (($category = $sdk_rate_plan->getDeveloperCategory()) && ($team = $this->teamMonitization->currentTeam())) {
        $team_category_access = AccessResult::allowedIf(($team_category = $team->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY')) && ($category->id() === $team_category))
          ->andIf(AccessResult::allowedIfHasPermission($account, "$operation rate_plan"));
        // Only return access allowed, as other cases might still be possible

--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanAccessControlHandler.php
@@ -21,6 +21,7 @@ namespace Drupal\apigee_m10n_teams\Entity\Access;
 
 use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
 use Drupal\apigee_edge_teams\Entity\Team;
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
@@ -91,6 +92,8 @@ class TeamRatePlanAccessControlHandler extends RatePlanAccessControlHandler {
     // Get the SDK rate plan.
     /** @var \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface $sdk_rate_plan */
     $sdk_rate_plan = $entity->decorated();
+
+    // Test access to CompanyRatePlanInterface.
     if ($sdk_rate_plan instanceof CompanyRatePlanInterface) {
       $company = $entity->getCompany();
       $team = $company instanceof CompanyInterface ? Team::load($company->id()) : NULL;
@@ -98,10 +101,21 @@ class TeamRatePlanAccessControlHandler extends RatePlanAccessControlHandler {
         ? $this->teamAccess->allowedIfHasTeamPermissions($team, $account, ["{$operation} rate_plan"])
         : AccessResult::forbidden('Unable to load the specified team of the team rate plan.');
     }
-    elseif ($sdk_rate_plan instanceof StandardRatePlanInterface && $this->teamMonitization->currentTeam()) {
-      return $this->teamMonitization->entityAccess($entity, $operation, $account);
+
+    // Test access to a DeveloperCategoryRatePlanInterface, where the team has
+    // the required category.
+    elseif ($sdk_rate_plan instanceof DeveloperCategoryRatePlanInterface) {
+     if (($category = $sdk_rate_plan->getDeveloperCategory()) && ($team = $this->teamMonitization->currentTeam())) {
+       $team_category_access = AccessResult::allowedIf(($team_category = $team->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY')) && ($category->id() === $team_category))
+         ->andIf(AccessResult::allowedIfHasPermission($account, "$operation rate_plan"));
+       // Only return access allowed, as other cases might still be possible
+       // and are checked on `parent::checkAccess()`.
+       if ($team_category_access->isAllowed()) {
+         return $team_category_access;
+       }
+      }
     }
-    // TODO: handle `CompanyCategoryRatePlan` rate plans if they exist.
+
     return parent::checkAccess($entity, $operation, $account);
   }
 

--- a/modules/apigee_m10n_teams/src/Entity/Permissions/MonetizationTeamPermissionsProvider.php
+++ b/modules/apigee_m10n_teams/src/Entity/Permissions/MonetizationTeamPermissionsProvider.php
@@ -18,7 +18,7 @@
  * MA 02110-1301, USA.
  */
 
-namespace Drupal\apigee_m10n_teams\Entity\Access;
+namespace Drupal\apigee_m10n_teams\Entity\Permissions;
 
 use Drupal\apigee_edge_teams\DynamicTeamPermissionProviderInterface;
 use Drupal\apigee_edge_teams\Structure\TeamPermission;

--- a/modules/apigee_m10n_teams/src/MonetizationTeams.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeams.php
@@ -25,6 +25,7 @@ use Apigee\Edge\Api\Monetization\Structure\LegalEntityTermsAndConditionsHistoryI
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface;
+use Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler;
 use Drupal\apigee_m10n_teams\Entity\Routing\MonetizationTeamsEntityRouteProvider;
 use Drupal\apigee_m10n_teams\Entity\Storage\TeamProductBundleStorage;
 use Drupal\apigee_m10n_teams\Entity\Storage\TeamPurchasedPlanStorage;
@@ -131,6 +132,7 @@ class MonetizationTeams implements MonetizationTeamsInterface {
       // Override the `html` route provider.
       $route_providers['html'] = MonetizationTeamsEntityRouteProvider::class;
       $entity_types['rate_plan']->setHandlerClass('route_provider', $route_providers);
+      $entity_types['rate_plan']->setHandlerClass('access', TeamRatePlanAccessControlHandler::class);
     }
 
     // Overrides for the purchased_plan entity.
@@ -173,15 +175,6 @@ class MonetizationTeams implements MonetizationTeamsInterface {
       $access = $this->teamAccessCheck()->allowedIfHasTeamPermissions($team, $account, ["{$operation} purchased_plan"]);
       // Team permission results completely override user permissions.
       return $access->isAllowed() ? $access : AccessResult::forbidden($access->getReason());
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function ratePlanAccess(EntityInterface $entity, $operation, AccountInterface $account) {
-    if ($team = $this->currentTeam()) {
-      return $this->entityAccess($entity, $operation, $account);
     }
   }
 

--- a/modules/apigee_m10n_teams/src/MonetizationTeams.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeams.php
@@ -179,26 +179,9 @@ class MonetizationTeams implements MonetizationTeamsInterface {
   /**
    * {@inheritdoc}
    */
-  public function purchasedPlanCreateAccess(AccountInterface $account, array $context, $entity_bundle) {
-    if (isset($context['team']) && $context['team'] instanceof TeamInterface) {
-      // Gat the access result.
-      $access = $this->teamAccessCheck()->allowedIfHasTeamPermissions($context['team'], $account, ["purchase rate_plan"]);
-      // Team permission results completely override user permissions.
-      return $access->isAllowed() ? $access : AccessResult::forbidden($access->getReason());
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function ratePlanAccess(EntityInterface $entity, $operation, AccountInterface $account) {
     if ($team = $this->currentTeam()) {
-      if ($operation === 'purchase') {
-        return $this->purchasedPlanCreateAccess($account, ['team' => $team], 'purchased_plan');
-      }
-      else {
-        return $this->entityAccess($entity, $operation, $account);
-      }
+      return $this->entityAccess($entity, $operation, $account);
     }
   }
 

--- a/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
@@ -95,21 +95,6 @@ interface MonetizationTeamsInterface {
   public function purchasedPlanAccess(EntityInterface $entity, $operation, AccountInterface $account);
 
   /**
-   * Handles `hook_purchased_plan_create_access` for `apigee_m10n_teams`.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The account requesting access.
-   * @param array $context
-   *   An array of relevant context.
-   * @param string $entity_bundle
-   *   This is always `purchased_plan`.
-   *
-   * @return \Drupal\Core\Access\AccessResultInterface|null
-   *   The access result or null for non-team routes.
-   */
-  public function purchasedPlanCreateAccess(AccountInterface $account, array $context, $entity_bundle);
-
-  /**
    * Handles `hook_rate_plan_access` for the `apigee_m10n_teams` module.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity

--- a/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
@@ -95,21 +95,6 @@ interface MonetizationTeamsInterface {
   public function purchasedPlanAccess(EntityInterface $entity, $operation, AccountInterface $account);
 
   /**
-   * Handles `hook_rate_plan_access` for the `apigee_m10n_teams` module.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The `rate_plan` entity.
-   * @param string $operation
-   *   The operation.
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The account requesting access.
-   *
-   * @return \Drupal\Core\Access\AccessResultInterface|null
-   *   The access result or null for non-team routes.
-   */
-  public function ratePlanAccess(EntityInterface $entity, $operation, AccountInterface $account);
-
-  /**
    * Check if company accepted latest terms and conditions.
    *
    * @param string $company_id

--- a/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
@@ -20,6 +20,7 @@
 namespace Drupal\Tests\apigee_m10n_teams\Kernel\Entity\Access;
 
 use Apigee\Edge\Api\Monetization\Entity\Company;
+use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlan;
 use Apigee\Edge\Api\Monetization\Entity\Developer;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategory;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlan;
@@ -215,7 +216,15 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     ]);
 
     $team = $this->createTeam();
+
+    /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamStorageInterface $team_storage */
+    $team_storage = $this->container->get('entity_type.manager')->getStorage('team');
+    $team = $team_storage->load($team->id());
     $team->decorated()->setAttribute('MINT_DEVELOPER_CATEGORY', $category->id());
+
+    $this->developer = $this->createAccount(['view rate_plan', 'purchase rate_plan']);
+    $this->createCurrentUserSession($this->developer);
+
     $this->addUserToTeam($team, $this->developer);
     $this->setCurrentTeamRoute($team);
 

--- a/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n_teams\Kernel\Entity\Access;
+
+use Apigee\Edge\Api\Monetization\Entity\Company;
+use Apigee\Edge\Api\Monetization\Entity\Developer;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategory;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlan;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlan;
+use Drupal\apigee_m10n\Entity\RatePlan;
+use Drupal\Tests\apigee_m10n_teams\Kernel\MonetizationTeamsKernelTestBase;
+use Drupal\Tests\apigee_m10n_teams\Traits\TeamProphecyTrait;
+
+/**
+ * Class TeamRatePlanAccessTest.
+ *
+ * @coversDefaultClass \Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ * @group apigee_m10n_teams
+ * @group apigee_m10n_teams_kernel
+ */
+class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBase {
+
+  use TeamProphecyTrait;
+
+  /**
+   * An apigee team.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $team;
+
+  /**
+   * The user with access.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $developer;
+
+  /**
+   * The control user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * The rate_plan access control handler.
+   *
+   * @var \Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler
+   */
+  protected $accessControlHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig([
+      'user',
+      'system',
+    ]);
+
+    // Enable the Classy theme.
+    \Drupal::service('theme_handler')->install(['classy']);
+    $this->config('system.theme')->set('default', 'classy')->save();
+
+    $this->accessControlHandler = $this->container->get('entity_type.manager')
+      ->getAccessControlHandler('rate_plan');
+
+    // Create root user.
+    $this->createAccount();
+
+    $this->developer = $this->createAccount(['view rate_plan', 'purchase rate_plan']);
+    $this->createCurrentUserSession($this->developer);
+
+    $this->user = $this->createAccount(['view rate_plan', 'purchase rate_plan']);
+
+  }
+
+  /**
+   * @covers ::checkAccess
+   * @throws \Exception
+   */
+  public function testAccess() {
+    // Ensure non-team access still works as expected.
+    $this->assertStandardRatePlan();
+    $this->assertDeveloperRatePlan();
+    $this->assertDeveloperCategoryRatePlan();
+
+    // Test team access.
+    $this->assertTeamRatePlan();
+    $this->assertTeamCategoryRatePlan();
+  }
+
+  /**
+   * Test \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface::TYPE_STANDARD rate plan.
+   *
+   * @throws \Exception
+   */
+  public function assertStandardRatePlan() {
+    $plan = $this->createRatePlan($this->createProductBundle());
+
+    $this->accessControlHandler->resetCache();
+    $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+  }
+
+  /**
+   * Tests \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface::TYPE_DEVELOPER rate plan.
+   */
+  public function assertDeveloperRatePlan() {
+    $developer_rate_plan = new DeveloperRatePlan([]);
+    $developer_rate_plan->setPackage($this->createProductBundle());
+    $developer_rate_plan->setDeveloper(new Developer([
+      'email' => $this->developer->getEmail(),
+      'name' => $this->developer->getDisplayName(),
+    ]));
+    $plan = RatePlan::createFrom($developer_rate_plan);
+
+    $this->accessControlHandler->resetCache();
+    $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->user, TRUE)->isAllowed());
+  }
+
+  /**
+   * Tests \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface::TYPE_DEVELOPER_CATEGORY rate plan.
+   */
+  public function assertDeveloperCategoryRatePlan() {
+    $category = new DeveloperCategory([
+      'id' => $this->getRandomUniqueId(),
+      'name' => $this->randomString(10),
+    ]);
+    $developer_category_rate_plan = new DeveloperCategoryRatePlan([]);
+    $developer_category_rate_plan->setDeveloperCategory($category);
+    $plan = RatePlan::createFrom($developer_category_rate_plan);
+
+    $this->accessControlHandler->resetCache();
+    $this->assertFalse($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->user, TRUE)->isAllowed());
+
+    // Set the developer category and test access.
+    /** @var \Drupal\apigee_edge\Entity\Storage\DeveloperStorageInterface $developer_storage */
+    $developer_storage = $this->container->get('entity_type.manager')->getStorage('developer');
+    $developer = $developer_storage->load($this->developer->getEmail());
+    $developer->decorated()->setAttribute('MINT_DEVELOPER_CATEGORY', $category->id());
+
+    $this->accessControlHandler->resetCache();
+    $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->user, TRUE)->isAllowed());
+  }
+
+  /**
+   * Tests \Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface rate plan.
+   */
+  public function assertTeamRatePlan() {
+    $team = $this->createTeam();
+    $this->addUserToTeam($team, $this->developer);
+
+    $company = new Company([
+      'id' => $team->id(),
+      'legalName' => $team->getName(),
+    ]);
+    $company_rate_plan = new CompanyRatePlan([
+      'id' => $this->randomMachineName(),
+      'company' => $company,
+    ]);
+
+    $plan = RatePlan::createFrom($company_rate_plan);
+
+    $this->accessControlHandler->resetCache();
+    $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->user, TRUE)->isAllowed());
+  }
+
+  /**
+   * Tests \Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface rate plan for teams.
+   */
+  public function assertTeamCategoryRatePlan() {
+    $category = new DeveloperCategory([
+      'id' => $this->getRandomUniqueId(),
+      'name' => $this->randomString(10),
+    ]);
+
+    $team = $this->createTeam();
+    $team->decorated()->setAttribute('MINT_DEVELOPER_CATEGORY', $category->id());
+    $this->addUserToTeam($team, $this->developer);
+    $this->setCurrentTeamRoute($team);
+
+    $developer_category_rate_plan = new DeveloperCategoryRatePlan([]);
+    $developer_category_rate_plan->setDeveloperCategory($category);
+    $plan = RatePlan::createFrom($developer_category_rate_plan);
+
+    $this->accessControlHandler->resetCache();
+    $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
+    $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
+    $this->assertFalse($plan->access('purchase', $this->user, TRUE)->isAllowed());
+  }
+
+}

--- a/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/Entity/Access/TeamRatePlanAccessControlHandlerTest.php
@@ -43,13 +43,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
   use TeamProphecyTrait;
 
   /**
-   * An apigee team.
-   *
-   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
-   */
-  protected $team;
-
-  /**
    * The user with access.
    *
    * @var \Drupal\user\UserInterface
@@ -62,13 +55,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
    * @var \Drupal\user\UserInterface
    */
   protected $user;
-
-  /**
-   * The rate_plan access control handler.
-   *
-   * @var \Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler
-   */
-  protected $accessControlHandler;
 
   /**
    * {@inheritdoc}
@@ -84,13 +70,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
       'system',
     ]);
 
-    // Enable the Classy theme.
-    \Drupal::service('theme_handler')->install(['classy']);
-    $this->config('system.theme')->set('default', 'classy')->save();
-
-    $this->accessControlHandler = $this->container->get('entity_type.manager')
-      ->getAccessControlHandler('rate_plan');
-
     // Create root user.
     $this->createAccount();
 
@@ -98,7 +77,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     $this->createCurrentUserSession($this->developer);
 
     $this->user = $this->createAccount(['view rate_plan', 'purchase rate_plan']);
-
   }
 
   /**
@@ -110,10 +88,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     $this->assertStandardRatePlan();
     $this->assertDeveloperRatePlan();
     $this->assertDeveloperCategoryRatePlan();
-
-    // Test team access.
-    $this->assertTeamRatePlan();
-    $this->assertTeamCategoryRatePlan();
   }
 
   /**
@@ -124,7 +98,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
   public function assertStandardRatePlan() {
     $plan = $this->createRatePlan($this->createProductBundle());
 
-    $this->accessControlHandler->resetCache();
+    \Drupal::entityTypeManager()->getAccessControlHandler('rate_plan')->resetCache();
     $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('view', $this->user, TRUE)->isAllowed());
@@ -143,7 +117,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     ]));
     $plan = RatePlan::createFrom($developer_rate_plan);
 
-    $this->accessControlHandler->resetCache();
+    \Drupal::entityTypeManager()->getAccessControlHandler('rate_plan')->resetCache();
     $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
@@ -162,7 +136,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     $developer_category_rate_plan->setDeveloperCategory($category);
     $plan = RatePlan::createFrom($developer_category_rate_plan);
 
-    $this->accessControlHandler->resetCache();
+    \Drupal::entityTypeManager()->getAccessControlHandler('rate_plan')->resetCache();
     $this->assertFalse($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
@@ -174,7 +148,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     $developer = $developer_storage->load($this->developer->getEmail());
     $developer->decorated()->setAttribute('MINT_DEVELOPER_CATEGORY', $category->id());
 
-    $this->accessControlHandler->resetCache();
+    \Drupal::entityTypeManager()->getAccessControlHandler('rate_plan')->resetCache();
     $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
@@ -184,7 +158,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
   /**
    * Tests \Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface rate plan.
    */
-  public function assertTeamRatePlan() {
+  public function testTeamRatePlan() {
     $team = $this->createTeam();
     $this->addUserToTeam($team, $this->developer);
 
@@ -199,7 +173,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
 
     $plan = RatePlan::createFrom($company_rate_plan);
 
-    $this->accessControlHandler->resetCache();
     $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());
@@ -209,7 +182,7 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
   /**
    * Tests \Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface rate plan for teams.
    */
-  public function assertTeamCategoryRatePlan() {
+  public function testTeamCategoryRatePlan() {
     $category = new DeveloperCategory([
       'id' => $this->getRandomUniqueId(),
       'name' => $this->randomString(10),
@@ -232,7 +205,6 @@ class TeamRatePlanAccessControlHandlerTest extends MonetizationTeamsKernelTestBa
     $developer_category_rate_plan->setDeveloperCategory($category);
     $plan = RatePlan::createFrom($developer_category_rate_plan);
 
-    $this->accessControlHandler->resetCache();
     $this->assertTrue($plan->access('view', $this->developer, TRUE)->isAllowed());
     $this->assertTrue($plan->access('purchase', $this->developer, TRUE)->isAllowed());
     $this->assertFalse($plan->access('view', $this->user, TRUE)->isAllowed());


### PR DESCRIPTION
Regarding [#162]: Adds access control to company rate plans, and category rate plans where the "category" attribute is inherited from the company/team.