### PR TITLE
#175 Fix admins can subscribe to a developer rate plan that was not created for them

### DIFF
--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanSubscriptionAccessHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanSubscriptionAccessHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Entity\Access;
+
+use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
+use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
+use Drupal\apigee_edge_teams\Entity\Team;
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_edge_teams\TeamMembershipManagerInterface;
+use Drupal\apigee_m10n\Entity\Access\RatePlanSubscriptionAccessHandler;
+use Drupal\apigee_m10n\Entity\RatePlanInterface;
+use Drupal\apigee_m10n_teams\MonetizationTeamsInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityHandlerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access check for subscribing an account to a rate plan, checking teams.
+ */
+class TeamRatePlanSubscriptionAccessHandler extends RatePlanSubscriptionAccessHandler {
+
+  /**
+   * Checks access to see if a tean can subscribe to a rate plan.
+   *
+   * This is different than access control, as an admin might have access to
+   * view and purchase a rate plan as any team, but they might not be able
+   * to subscribe to the plan in a certain team context.
+   *
+   * @param \Drupal\apigee_m10n\Entity\RatePlanInterface $rate_plan_entity
+   *   The rate plan drupal entity.
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface|null
+   *   The team for which we try to determine subscription access.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The result specifying if subscription to the rate plan is or not allowed.
+   */
+  public function teamAccess(RatePlanInterface $rate_plan_entity, TeamInterface $team): AccessResultInterface {
+    /** @var \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface $rate_plan */
+    $rate_plan = $rate_plan_entity->decorated();
+
+    // Test access to CompanyRatePlanInterface.
+    if ($rate_plan instanceof CompanyRatePlanInterface) {
+      $company = $rate_plan->getCompany();
+      $team_id = $company instanceof CompanyInterface ? $company->id() : NULL;
+      return AccessResult::allowedIf($team_id == $team->id());
+    }
+
+    // Test access to a DeveloperCategoryRatePlanInterface, where the team has
+    // the required category.
+    if ($rate_plan instanceof DeveloperCategoryRatePlanInterface) {
+      $category = $rate_plan->getDeveloperCategory();
+      $current_team_category = $team->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY');
+      return AccessResult::allowedIf($current_team_category && $category && ($category->id() === $current_team_category));
+    }
+
+    // A team can't subscribe to a Company rate plan.
+    if ($rate_plan instanceof DeveloperRatePlanInterface) {
+      return AccessResult::forbidden();
+    }
+
+    return AccessResult::allowed();
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanSubscriptionAccessHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamRatePlanSubscriptionAccessHandler.php
@@ -23,21 +23,11 @@ use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
-use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
-use Drupal\apigee_edge_teams\Entity\Team;
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
-use Drupal\apigee_edge_teams\TeamMembershipManagerInterface;
 use Drupal\apigee_m10n\Entity\Access\RatePlanSubscriptionAccessHandler;
 use Drupal\apigee_m10n\Entity\RatePlanInterface;
-use Drupal\apigee_m10n_teams\MonetizationTeamsInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
-use Drupal\Core\Entity\EntityHandlerInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Routing\Access\AccessInterface;
-use Drupal\user\UserInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Access check for subscribing an account to a rate plan, checking teams.
@@ -53,7 +43,7 @@ class TeamRatePlanSubscriptionAccessHandler extends RatePlanSubscriptionAccessHa
    *
    * @param \Drupal\apigee_m10n\Entity\RatePlanInterface $rate_plan_entity
    *   The rate plan drupal entity.
-   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface|null
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface $team
    *   The team for which we try to determine subscription access.
    *
    * @return \Drupal\Core\Access\AccessResultInterface

--- a/modules/apigee_m10n_teams/src/MonetizationTeams.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeams.php
@@ -26,6 +26,7 @@ use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface;
 use Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler;
+use Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanSubscriptionAccessHandler;
 use Drupal\apigee_m10n_teams\Entity\Routing\MonetizationTeamsEntityRouteProvider;
 use Drupal\apigee_m10n_teams\Entity\Storage\TeamProductBundleStorage;
 use Drupal\apigee_m10n_teams\Entity\Storage\TeamPurchasedPlanStorage;
@@ -133,6 +134,7 @@ class MonetizationTeams implements MonetizationTeamsInterface {
       $route_providers['html'] = MonetizationTeamsEntityRouteProvider::class;
       $entity_types['rate_plan']->setHandlerClass('route_provider', $route_providers);
       $entity_types['rate_plan']->setHandlerClass('access', TeamRatePlanAccessControlHandler::class);
+      $entity_types['rate_plan']->setHandlerClass('subscription_access', TeamRatePlanSubscriptionAccessHandler::class);
     }
 
     // Overrides for the purchased_plan entity.

--- a/src/Controller/PricingAndPlansController.php
+++ b/src/Controller/PricingAndPlansController.php
@@ -116,12 +116,18 @@ class PricingAndPlansController extends ControllerBase {
     }
 
     $rate_plans = [];
+    $subscription_handler = \Drupal::entityTypeManager()->getHandler('rate_plan', 'subscription_access');
 
     // Load rate plans for each product bundle.
     foreach (ProductBundle::getAvailableProductBundlesByDeveloper($user->getEmail()) as $product_bundle) {
       /** @var \Drupal\apigee_m10n\Entity\ProductBundleInterface $product_bundle */
       foreach ($product_bundle->get('ratePlans') as $rate_plan) {
-        $rate_plans["{$product_bundle->id()}:{$rate_plan->target_id}"] = $rate_plan->entity;
+
+        /** @var \Drupal\apigee_m10n\Entity\RatePlanInterface $rate_plan_entity */
+        $rate_plan_entity = $rate_plan->entity;
+        if ($subscription_handler->access($rate_plan_entity, $user) == AccessResult::allowed()) {
+          $rate_plans["{$product_bundle->id()}:{$rate_plan->target_id}"] = $rate_plan->entity;
+        }
       };
     }
 

--- a/src/Entity/Access/RatePlanSubscriptionAccessHandler.php
+++ b/src/Entity/Access/RatePlanSubscriptionAccessHandler.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\apigee_m10n\Entity\Access;
 
+use Apigee\Edge\Api\Monetization\Entity\CompanyRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
 use Drupal\apigee_m10n\Entity\RatePlanInterface;
@@ -99,6 +100,10 @@ class RatePlanSubscriptionAccessHandler implements AccessInterface, EntityHandle
         return AccessResult::allowedIf($account->getEmail() === $developer->getEmail());
       }
       return AccessResult::forbidden("User {$developer->getEmail()} cannot subscribe to developer rate plan.");
+    }
+
+    if ($rate_plan instanceof CompanyRatePlanInterface) {
+      return AccessResult::forbidden();
     }
 
     return AccessResult::allowed();

--- a/src/Entity/Access/RatePlanSubscriptionAccessHandler.php
+++ b/src/Entity/Access/RatePlanSubscriptionAccessHandler.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Entity\Access;
+
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
+use Drupal\apigee_m10n\Entity\RatePlanInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityHandlerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access check for subscribing an account to a rate plan.
+ */
+class RatePlanSubscriptionAccessHandler implements AccessInterface, EntityHandlerInterface {
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a RatePlanSubscriptionAccessCheck object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Checks access to see if an account can subscribe to a rate plan.
+   *
+   * This is different than access control, as an admin might have access to
+   * view and purchase a rate plan as any developer, but they might not be able
+   * to subscribe to the plan themselves.
+   *
+   * @param \Drupal\apigee_m10n\Entity\RatePlanInterface $rate_plan_entity
+   *   The rate plan drupal entity.
+   * @param \Drupal\user\UserInterface $account
+   *   The account for which we try to determine subscription access.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The result specifying if subscription to the rate plan is or not allowed.
+   */
+  public function access(RatePlanInterface $rate_plan_entity, UserInterface $account): AccessResultInterface {
+    /** @var \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface $rate_plan */
+    $rate_plan = $rate_plan_entity->decorated();
+
+    // If rate plan is a developer category rate plan, deny access if developer
+    // does not belong to rate_plan category.
+    /** @var \Drupal\apigee_edge\Entity\DeveloperInterface $developer */
+    if ($rate_plan instanceof DeveloperCategoryRatePlanInterface) {
+      $developer_storage = $this->entityTypeManager->getStorage('developer');
+      if (($category = $rate_plan->getDeveloperCategory()) && ($developer = $developer_storage->load($account->getEmail()))) {
+        return AccessResult::allowedIf(($developer_category = $developer->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY')) && ($category->id() === $developer_category));
+      }
+      return AccessResult::forbidden("User {$developer->getEmail()} missing required developer category.");
+    }
+
+    // If rate plan is a developer rate plan, and the assigned developer is
+    // different from account, deny access.
+    if ($rate_plan instanceof DeveloperRatePlanInterface) {
+      if ($developer = $rate_plan->getDeveloper()) {
+        return AccessResult::allowedIf($account->getEmail() === $developer->getEmail());
+      }
+      return AccessResult::forbidden("User {$developer->getEmail()} cannot subscribe to developer rate plan.");
+    }
+
+    return AccessResult::allowed();
+  }
+
+}

--- a/src/Entity/RatePlan.php
+++ b/src/Entity/RatePlan.php
@@ -19,6 +19,9 @@
 
 namespace Drupal\apigee_m10n\Entity;
 
+use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperInterface;
+use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\RatePlan as MonetizationRatePlan;
 use Apigee\Edge\Api\Monetization\Entity\RatePlanRevisionInterface;
 use Apigee\Edge\Api\Monetization\Entity\StandardRatePlan;
@@ -601,6 +604,31 @@ class RatePlan extends FieldableEdgeEntityBase implements RatePlanInterface {
       ->get('entity')
       ->getValue()
       ->getApiProducts();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType(): string {
+    if ($this->decorated instanceof DeveloperRatePlanInterface) {
+      return RatePlanInterface::TYPE_DEVELOPER;
+    }
+    elseif ($this->decorated instanceof DeveloperCategoryRatePlanInterface) {
+      return RatePlanInterface::TYPE_DEVELOPER_CATEGORY;
+    }
+
+    return RatePlanInterface::TYPE_STANDARD;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDeveloper(): ?DeveloperInterface {
+    if ($this->decorated instanceof DeveloperRatePlanInterface) {
+      return $this->decorated->getDeveloper();
+    }
+
+    return NULL;
   }
 
 }

--- a/src/Entity/RatePlan.php
+++ b/src/Entity/RatePlan.php
@@ -58,6 +58,7 @@ use Drupal\user\Entity\User;
  *   handlers = {
  *     "storage" = "Drupal\apigee_m10n\Entity\Storage\RatePlanStorage",
  *     "access" = "Drupal\apigee_m10n\Entity\Access\RatePlanAccessControlHandler",
+ *     "subscription_access" = "Drupal\apigee_m10n\Entity\Access\RatePlanSubscriptionAccessHandler",
  *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
  *   },
  *   links = {

--- a/tests/modules/apigee_mock_client/tests/response-templates/rate-plan.json.twig
+++ b/tests/modules/apigee_mock_client/tests/response-templates/rate-plan.json.twig
@@ -73,5 +73,8 @@
     "setUpFee":                 {{ plan.setUpFee|default('1.0000') }},
     "startDate":                "{{ plan.startDate|date('Y-m-d 00:00:00')|default(date('today -1 day')|date('Y-m-d 00:00:00')) }}",
     "endDate":                  "{{ plan.endDate|date('Y-m-d 00:00:00')|default('null') }}",
+    {% if plan.type == "DEVELOPER" %}
+    "developer" : {% include 'monetization-developer.json.twig' with { "developer": plan.developer } %},
+    {% endif %}
     "type":                     "{{ plan.type|default('STANDARD') }}"
 }


### PR DESCRIPTION
Fixes #175. On a plans and pricing page it will filter out rate plans (user/{user}/plans) that the user cannot subscribe to (using the account from the URL, not the logged-in user, as that might be different). An analogous check is used on the teams plans page as well (/teams/{team}/plans).