### PR TITLE
[#187] Update the "unit price" label in the add credit submodule.

### DIFF
--- a/modules/apigee_m10n_add_credit/src/AddCreditService.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditService.php
@@ -309,6 +309,32 @@ class AddCreditService implements AddCreditServiceInterface {
         }
       }
     }
+
+    // Update the label for the unit price for add_credit products.
+    $this->addToCartFormAlter($form, $form_state, $form_id);
+  }
+
+  /**
+   * Update the label for the unit price for add_credit products.
+   *
+   * @param array $form
+   *   The form to alter.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param string $form_id
+   *   The form id.
+   */
+  protected function addToCartFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    if (strpos($form_id, 'commerce_order_item_add_to_cart_form') === 0) {
+      $order_item = $form_state->getFormObject()->getEntity();
+      $purchased_entity = $order_item->getPurchasedEntity();
+      $product = $purchased_entity->getProduct();
+
+      // Update the label for the unit price for add_credit products.
+      if ($product->get(AddCreditConfig::ADD_CREDIT_ENABLED_FIELD_NAME)->value) {
+        $form['unit_price']['widget'][0]['amount']['#title'] = t('Amount to be added to your account balance');
+      }
+    }
   }
 
   /**

--- a/modules/apigee_m10n_add_credit/src/Plugin/Validation/Constraint/PriceRangeUnitPriceConstraint.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Validation/Constraint/PriceRangeUnitPriceConstraint.php
@@ -36,21 +36,21 @@ class PriceRangeUnitPriceConstraint extends Constraint {
    *
    * @var string
    */
-  public $rangeMessage = 'The unit price value must be between @minimum and @maximum.';
+  public $rangeMessage = 'The amount must be between @minimum and @maximum.';
 
   /**
    * The validation message when value is less than minimum price.
    *
    * @var string
    */
-  public $minMessage = 'This unit price cannot be less than @minimum.';
+  public $minMessage = 'This amount cannot be less than @minimum.';
 
   /**
    * The validation message when value is greater than maximum price.
    *
    * @var string
    */
-  public $maxMessage = 'This unit price cannot be greater than @maximum.';
+  public $maxMessage = 'This amount cannot be greater than @maximum.';
 
   /**
    * The validation message when currency is invalid.

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
@@ -339,7 +339,7 @@ class AddCreditCustomAmountTest extends AddCreditFunctionalJavascriptTestBase {
         30.00,
         25.00,
         35.00,
-        'The amount value must be between USD20.00 and USD30.00.',
+        'The amount must be between USD20.00 and USD30.00.',
       ],
       [
         20.00,

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
@@ -339,21 +339,21 @@ class AddCreditCustomAmountTest extends AddCreditFunctionalJavascriptTestBase {
         30.00,
         25.00,
         35.00,
-        'The unit price value must be between USD20.00 and USD30.00.',
+        'The amount value must be between USD20.00 and USD30.00.',
       ],
       [
         20.00,
         NULL,
         25.00,
         15.00,
-        'This unit price cannot be less than USD20.00.',
+        'This amount cannot be less than USD20.00.',
       ],
       [
         20.00,
         NULL,
         NULL,
         15.00,
-        'This unit price cannot be less than USD20.00.',
+        'This amount cannot be less than USD20.00.',
       ],
     ];
   }


### PR DESCRIPTION
Follow up on #178 : 

> The field label "Unit price" is not very clear. Kickstart renames this field to "Amount to be added to your account balance", and that seems better. Validation messages and tests will need to be updated to match as needed.