### PR TITLE
Fix tests because commerce 8.x-2.14 requires profile

### DIFF
--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/AddCreditConfigStatusKernelTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/AddCreditConfigStatusKernelTest.php
@@ -17,7 +17,7 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-namespace Drupal\Tests\apigee_m10n_add_credit\Functional;
+namespace Drupal\Tests\apigee_m10n_add_credit\Kernel;
 
 use Apigee\Edge\Api\Monetization\Entity\SupportedCurrency;
 use Drupal\apigee_m10n_add_credit\AddCreditConfig;
@@ -29,9 +29,9 @@ use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
  * Tests the status page for add credit.
  *
  * @group apigee_m10n
- * @group apigee_m10n_functional
+ * @group apigee_m10n_kernel
  * @group apigee_m10n_add_credit
- * @group apigee_m10n_add_credit_functional
+ * @group apigee_m10n_add_credit_kernel
  */
 class AddCreditConfigStatusKernelTest extends MonetizationKernelTestBase {
 
@@ -54,6 +54,7 @@ class AddCreditConfigStatusKernelTest extends MonetizationKernelTestBase {
     // Modules for this test.
     'apigee_m10n_add_credit',
     'address',
+    'profile',
     'commerce_order',
     'commerce_price',
     'commerce_product',

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
@@ -75,6 +75,7 @@ class BalanceAdjustmentJobKernelTest extends MonetizationKernelTestBase {
     'system',
     // Modules for this test.
     'apigee_m10n_add_credit',
+    'profile',
     'commerce_order',
     'commerce_price',
     'commerce',
@@ -98,6 +99,7 @@ class BalanceAdjustmentJobKernelTest extends MonetizationKernelTestBase {
       'system',
     ]);
     $this->installEntitySchema('user');
+    $this->installEntitySchema('profile');
     \Drupal::service('commerce_price.currency_importer')->importByCountry('US');
 
     $this->developer = $this->createAccount();

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/AddCreditEntityTypeManagerTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/AddCreditEntityTypeManagerTest.php
@@ -62,6 +62,7 @@ class AddCreditEntityTypeManagerTest extends MonetizationKernelTestBase {
 
     // Modules for this test.
     'apigee_m10n_add_credit',
+    'profile',
     'commerce_order',
     'commerce_price',
     'commerce_product',
@@ -83,6 +84,7 @@ class AddCreditEntityTypeManagerTest extends MonetizationKernelTestBase {
       'system',
     ]);
     $this->installEntitySchema('user');
+    $this->installEntitySchema('profile');
 
     $this->manager = $this->container->get('plugin.manager.apigee_add_credit_entity_type');
   }

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/EntityReferenceSelection/AddCreditProductsSelectionTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/EntityReferenceSelection/AddCreditProductsSelectionTest.php
@@ -71,6 +71,7 @@ class AddCreditProductsSelectionTest extends MonetizationKernelTestBase {
 
     // Modules for this test.
     'apigee_m10n_add_credit',
+    'profile',
     'commerce_order',
     'commerce_price',
     'commerce_product',


### PR DESCRIPTION
A new release of Commerce ([8.x-2.14](https://www.drupal.org/project/commerce/releases/8.x-2.14)) now requires the profile module, so some tests were failing. This PR fixes that.