### PR TITLE
#195 Remove prepaid tab for postpaid developers

### DIFF
--- a/apigee_m10n.links.task.yml
+++ b/apigee_m10n.links.task.yml
@@ -10,20 +10,20 @@ entity.product_bundle.collection:
   base_route: apigee_m10n.settings.product_bundle
 
 apigee_m10n.balance_and_plans:
-  route_name: apigee_monetization.billing
+  route_name: entity.purchased_plan.developer_collection
   title: 'Balance and plans'
   base_route: entity.user.canonical
-
-apigee_m10n.billing:
-  title: 'Prepaid balance'
-  route_name: apigee_monetization.billing
-  base_route: entity.user.canonical
-  parent_id: apigee_m10n.balance_and_plans
-  weight: -2
 
 apigee_m10n.purchased_plans:
   title: 'Purchased plans'
   route_name: entity.purchased_plan.developer_collection
+  base_route: entity.user.canonical
+  parent_id: apigee_m10n.balance_and_plans
+  weight: -2
+
+apigee_m10n.billing:
+  title: 'Prepaid balance'
+  route_name: apigee_monetization.billing
   base_route: entity.user.canonical
   parent_id: apigee_m10n.balance_and_plans
   weight: -1

--- a/src/Controller/PrepaidBalanceController.php
+++ b/src/Controller/PrepaidBalanceController.php
@@ -45,7 +45,7 @@ class PrepaidBalanceController extends PrepaidBalanceControllerBase {
   }
 
   /**
-   * Checks current users access.
+   * Checks current users access and if developer is prepaid.
    *
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
@@ -53,10 +53,14 @@ class PrepaidBalanceController extends PrepaidBalanceControllerBase {
    *   Run access checks for this account.
    *
    * @return \Drupal\Core\Access\AccessResult
-   *   Grants access to the route if passed permissions are present.
+   *   Grants access to the route if passed permissions are present and given
+   *   developer is prepaid.
    */
   public function access(RouteMatchInterface $route_match, AccountInterface $account) {
     $user = $route_match->getParameter('user');
+    if (!$this->monetization->isDeveloperPrepaid($user)) {
+      return AccessResult::forbidden('Developer is not prepaid.');
+    }
     return AccessResult::allowedIf(
       $account->hasPermission('view any prepaid balance') ||
       ($account->hasPermission('view own prepaid balance') && $account->id() === $user->id())

--- a/src/MonetizationInterface.php
+++ b/src/MonetizationInterface.php
@@ -52,6 +52,11 @@ interface MonetizationInterface {
   ];
 
   /**
+   * Developer billing type attribute name.
+   */
+  const BILLING_TYPE_ATTR = 'MINT_BILLING_TYPE';
+
+  /**
    * Tests whether the current organization has monetization enabled.
    *
    * A monitization enabled org is a requirement for using this module.
@@ -217,5 +222,16 @@ interface MonetizationInterface {
    *   The organization entity.
    */
   public function getOrganization(): ?OrganizationInterface;
+
+  /**
+   * Returns true if developer billing type is prepaid, false if postpaid.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   The developer account.
+   *
+   * @return bool
+   *   True if developer is prepaid.
+   */
+  public function isDeveloperPrepaid(UserInterface $account): bool;
 
 }

--- a/tests/modules/apigee_mock_client/tests/response-templates/developer.json.twig
+++ b/tests/modules/apigee_mock_client/tests/response-templates/developer.json.twig
@@ -10,6 +10,7 @@
  * - developer: The user account for the developer.
  * - org_name: The name of the organization.
  * - companies: A list of companies.
+ * - billing_type: the billing type, defaults to "PREPAID".
  */
 #}
 {
@@ -29,7 +30,7 @@
     "attributes" : [
         {
             "name" : "MINT_BILLING_TYPE",
-            "value" : "PREPAID"
+            "value" : "{{ billing_type|default('PREPAID') }}"
         },
         {
             "name" : "MINT_DEVELOPER_TYPE",

--- a/tests/src/Functional/NavigationTest.php
+++ b/tests/src/Functional/NavigationTest.php
@@ -77,31 +77,23 @@ class NavigationTest extends MonetizationFunctionalTestBase {
     $this->assertCssElementContains('.block-menu.navigation.menu--account', 'My account');
 
     $this->warmOrganizationCache();
-    $this->stack->queueMockResponse([
-      'get-prepaid-balances' => [
-        "current_aud" => 100.0000,
-        "current_total_aud" => 200.0000,
-        "current_usage_aud" => 50.0000,
-        "topups_aud" => 50.0000,
+    $product_bundle = $this->createProductBundle();
+    $rate_plan = $this->createRatePlan($product_bundle);
+    $purchased_plan = $this->createPurchasedPlan($this->developer, $rate_plan);
 
-        "current_usd" => 72.2000,
-        "current_total_usd" => 120.0200,
-        "current_usage_usd" => 47.8200,
-        "topups_usd" => 30.0200,
+    $this->stack->queueMockResponse([
+      'get_developer_purchased_plans' => [
+        'purchased_plans' => [$purchased_plan],
       ],
-    ]);
-
-    $this->stack->queueMockResponse([
-      'get-supported-currencies',
     ]);
 
     // Check the manage Balance and plans link.
     $this->clickLink('Balance and plans');
-    $session->linkExists('Prepaid balance');
     $session->linkExists('Purchased plans');
+    $session->linkExists('Prepaid balance');
     $session->linkExists('Billing Details');
-    $this->assertCssElementContains('nav.tabs', 'Prepaid balance');
     $this->assertCssElementContains('nav.tabs', 'Purchased plans');
+    $this->assertCssElementContains('nav.tabs', 'Prepaid balance');
     $this->assertCssElementContains('nav.tabs', 'Billing Details');
   }
 

--- a/tests/src/Kernel/Access/AccessKernelTest.php
+++ b/tests/src/Kernel/Access/AccessKernelTest.php
@@ -49,6 +49,13 @@ class AccessKernelTest extends MonetizationKernelTestBase {
   protected $developer;
 
   /**
+   * Drupal developer user account with billing type as POSTPAID.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $postpaid;
+
+  /**
    * Drupal anonymous user account.
    *
    * @var \Drupal\Core\Session\AccountInterface
@@ -107,6 +114,13 @@ class AccessKernelTest extends MonetizationKernelTestBase {
     $this->product_bundle = $this->createProductBundle();
     $this->rate_plan = $this->createRatePlan($this->product_bundle);
 
+    // Create a postpaid developer.
+    $this->postpaid = $this->createAccount([
+      'view product_bundle',
+      'view own purchased_plan',
+      'view rate_plan',
+    ], TRUE, '', ['billing_type' => 'POSTPAID']);
+
     $this->prophesizeCurrentUser([]);
   }
 
@@ -140,6 +154,14 @@ class AccessKernelTest extends MonetizationKernelTestBase {
       'user' => $this->administrator->id(),
     ]);
     static::assertTrue($prepaid_balance_url->access($this->administrator));
+    static::assertFalse($prepaid_balance_url->access($this->developer));
+    static::assertFalse($prepaid_balance_url->access($this->anonymous));
+
+    // Prepaid balance pages should return access denied for a postpaid dev.
+    $prepaid_balance_url = Url::fromRoute('apigee_monetization.billing', [
+      'user' => $this->postpaid->id(),
+    ]);
+    static::assertFalse($prepaid_balance_url->access($this->administrator));
     static::assertFalse($prepaid_balance_url->access($this->developer));
     static::assertFalse($prepaid_balance_url->access($this->anonymous));
 

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -151,7 +151,7 @@ trait ApigeeMonetizationTestTrait {
    *
    * {@inheritdoc}
    */
-  protected function createAccount(array $permissions = [], bool $status = TRUE, string $prefix = ''): ?UserInterface {
+  protected function createAccount(array $permissions = [], bool $status = TRUE, string $prefix = '', $attributes = []): ?UserInterface {
     $rid = NULL;
     if ($permissions) {
       $rid = $this->createRole($permissions);
@@ -177,8 +177,10 @@ trait ApigeeMonetizationTestTrait {
 
     $account = User::create($edit);
 
+    $billing_type = empty($attributes['billing_type']) ? NULL : $attributes['billing_type'];
+
     // Queue up a created response.
-    $this->queueDeveloperResponse($account, 201);
+    $this->queueDeveloperResponse($account, 201, $billing_type);
 
     // Save the user.
     $account->save();
@@ -197,9 +199,9 @@ trait ApigeeMonetizationTestTrait {
     $this->cleanup_queue[] = [
       'weight' => 99,
       // Prepare for deleting the developer.
-      'callback' => function () use ($account) {
-        $this->queueDeveloperResponse($account);
-        $this->queueDeveloperResponse($account);
+      'callback' => function () use ($account, $billing_type) {
+        $this->queueDeveloperResponse($account, NULL, $billing_type);
+        $this->queueDeveloperResponse($account, NULL, $billing_type);
         // Delete it.
         $account->delete();
       },
@@ -476,11 +478,15 @@ trait ApigeeMonetizationTestTrait {
    * @param string|null $response_code
    *   Add a response code to override the default.
    */
-  protected function queueDeveloperResponse(UserInterface $developer, $response_code = NULL) {
+  protected function queueDeveloperResponse(UserInterface $developer, $response_code = NULL, $billing_type = NULL) {
     $context = empty($response_code) ? [] : ['status_code' => $response_code];
 
     $context['developer'] = $developer;
     $context['org_name'] = $this->sdk_connector->getOrganization();
+
+    if ($billing_type) {
+      $context['billing_type'] = $billing_type;
+    }
 
     $this->stack->queueMockResponse(['get_developer' => $context]);
   }

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -477,6 +477,8 @@ trait ApigeeMonetizationTestTrait {
    *   The developer user to get properties from.
    * @param string|null $response_code
    *   Add a response code to override the default.
+   * @param string|null $billing_type
+   *   The developer billing type.
    */
   protected function queueDeveloperResponse(UserInterface $developer, $response_code = NULL, $billing_type = NULL) {
     $context = empty($response_code) ? [] : ['status_code' => $response_code];


### PR DESCRIPTION
Fixes #195 . Removes the prepaid tab for post-paid developers. It also changes the "Balance and plans" default tab from the "prepaid balances" to the "purchased plans" tab, so postpaid developers do not lose navigation links.