### PR TITLE
[#174] Add tests for custom field types and formatters

### DIFF
--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+
+/**
+ * Test the `apigee_date_and_text_formatter` field formatter.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class DateAndTextFormatterKernelTest extends MonetizationKernelTestBase {
+
+  /**
+   * The formatter manager.
+   *
+   * @var \Drupal\Core\Field\FormatterPluginManager
+   */
+  protected $formatter_manager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $field_manager;
+
+  /**
+   * The field's display settings.
+   *
+   * @var array
+   */
+  protected $settings;
+
+  /**
+   * Extra modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'text',
+    'entity_test',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['system']);
+    $this->installConfig(['field']);
+    $this->installEntitySchema('entity_test');
+
+    $this->entityType = 'entity_test';
+    $this->bundle = $this->entityType;
+    $this->fieldName = mb_strtolower($this->randomMachineName());
+
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => $this->fieldName,
+      'entity_type' => $this->entityType,
+      'type' => 'timestamp',
+    ]);
+    $field_storage->save();
+
+    $instance = FieldConfig::create([
+      'field_storage' => $field_storage,
+      'bundle' => $this->bundle,
+      'label' => $this->randomMachineName(),
+    ]);
+    $instance->save();
+
+    $this->display = entity_get_display($this->entityType, $this->bundle, 'default')
+      ->setComponent($this->fieldName, [
+        'type' => 'boolean',
+        'settings' => [],
+      ]);
+    $this->display->save();
+
+    $this->settings = [
+      'date_format' => 'custom',
+      'custom_date_format' => 'm/d/Y',
+      'timezone' => '',
+      'text' => 'Lorem ipsum dolor sit amet, @date consectetur adipiscing elit.',
+    ];
+  }
+
+  /**
+   * Test formatter display.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function testView() {
+    $value = time();
+
+    // Grab the formatted date from the TimestampFormatter and add it to the
+    // text.
+    $expected_date = \Drupal::service('date.formatter')
+      ->format($value, $this->settings['date_format'], $this->settings['custom_date_format']);
+    $expected = new FormattableMarkup($this->settings['text'], [
+      '@date' => $expected_date,
+    ]);
+
+    $component = $this->display->getComponent($this->fieldName);
+    $component['type'] = 'apigee_date_and_text_formatter';
+    $component['settings'] = $this->settings;
+    $this->display->setComponent($this->fieldName, $component);
+
+    $entity = EntityTest::create([]);
+    $entity->{$this->fieldName}->value = $value;
+
+    $content = $this->display->build($entity);
+    $this->render($content);
+    $this->assertRaw($expected);
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
@@ -38,14 +38,14 @@ class DateAndTextFormatterKernelTest extends MonetizationKernelTestBase {
    *
    * @var \Drupal\Core\Field\FormatterPluginManager
    */
-  protected $formatter_manager;
+  protected $formatterManager;
 
   /**
    * The entity field manager.
    *
    * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
-  protected $field_manager;
+  protected $fieldManager;
 
   /**
    * The field's display settings.
@@ -95,7 +95,8 @@ class DateAndTextFormatterKernelTest extends MonetizationKernelTestBase {
     ]);
     $instance->save();
 
-    $this->display = entity_get_display($this->entityType, $this->bundle, 'default')
+    $this->display = $this->container->get('entity_display.repository')
+      ->getViewDisplay($this->entityType, $this->bundle, 'default')
       ->setComponent($this->fieldName, [
         'type' => 'boolean',
         'settings' => [],

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/DateAndTextFormatterKernelTest.php
@@ -95,6 +95,8 @@ class DateAndTextFormatterKernelTest extends MonetizationKernelTestBase {
     ]);
     $instance->save();
 
+    // Set the default display for the field to a simple formatter (boolean); we
+    // later switch it to the actual formatter during the test.
     $this->display = $this->container->get('entity_display.repository')
       ->getViewDisplay($this->entityType, $this->bundle, 'default')
       ->setComponent($this->fieldName, [

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/DatestampFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/DatestampFormatterKernelTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\apigee_m10n\Plugin\Field\FieldFormatter\DatestampFormatter;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+
+/**
+ * Test the `apigee_datestamp` field formatter.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class DatestampFormatterKernelTest extends MonetizationKernelTestBase {
+
+  /**
+   * The formatter manager.
+   *
+   * @var \Drupal\Core\Field\FormatterPluginManager
+   */
+  protected $formatter_manager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $field_manager;
+
+  /**
+   * Test product bundle.
+   *
+   * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
+   */
+  protected $product_bundle;
+
+  /**
+   * Test rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
+   */
+  protected $rate_plan;
+
+  /**
+   * Test purchased rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\PurchasedPlanInterface
+   */
+  protected $purchased_plan;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig([
+      'user',
+    ]);
+
+    // Do not use user 1.
+    $this->createAccount();
+    $developer = $this->createAccount(MonetizationInterface::DEFAULT_AUTHENTICATED_PERMISSIONS);
+
+    $this->product_bundle = $this->createProductBundle();
+    $this->rate_plan = $this->createRatePlan($this->product_bundle);
+    $this->purchased_plan = $this->createPurchasedPlan($developer, $this->rate_plan);
+
+    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
+    $this->field_manager = $this->container->get('entity_field.manager');
+  }
+
+  /**
+   * Test formatter display.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function testView() {
+    $date_format = 'custom';
+    $custom_date_format = 'm/d/Y';
+    $item_list = $this->purchased_plan->get('startDate');
+    static::assertInstanceOf(FieldItemList::class, $item_list);
+    /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\DatestampFormatter $instance */
+    $instance = $this->formatter_manager->createInstance('apigee_datestamp', [
+      'field_definition' => $this->field_manager->getBaseFieldDefinitions('rate_plan')['startDate'],
+      'settings' => [
+        'date_format' => $date_format,
+        'custom_date_format' => $custom_date_format,
+        'timezone' => '',
+      ],
+      'label' => TRUE,
+      'view_mode' => 'default',
+      'third_party_settings' => [],
+    ]);
+    static::assertInstanceOf(DatestampFormatter::class, $instance);
+
+    /* @var \DateTimeImmutable $value */
+    $value = $this->purchased_plan->getStartDate();
+    $expected = \Drupal::service('date.formatter')
+      ->format($value->getTimestamp(), $date_format, $custom_date_format);
+
+    // Render the field item.
+    $build = $instance->view($item_list);
+
+    static::assertSame('Start Date', (string) $build['#title']);
+    static::assertTrue($build['#label_display']);
+    static::assertSame($expected, (string) $build[0]['#markup']);
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/DatestampFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/DatestampFormatterKernelTest.php
@@ -37,35 +37,35 @@ class DatestampFormatterKernelTest extends MonetizationKernelTestBase {
    *
    * @var \Drupal\Core\Field\FormatterPluginManager
    */
-  protected $formatter_manager;
+  protected $formatterManager;
 
   /**
    * The entity field manager.
    *
    * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
-  protected $field_manager;
+  protected $fieldManager;
 
   /**
    * Test product bundle.
    *
    * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
    */
-  protected $product_bundle;
+  protected $productBundle;
 
   /**
    * Test rate plan.
    *
    * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
    */
-  protected $rate_plan;
+  protected $ratePlan;
 
   /**
    * Test purchased rate plan.
    *
    * @var \Drupal\apigee_m10n\Entity\PurchasedPlanInterface
    */
-  protected $purchased_plan;
+  protected $purchasedPlan;
 
   /**
    * {@inheritdoc}
@@ -84,12 +84,12 @@ class DatestampFormatterKernelTest extends MonetizationKernelTestBase {
     $this->createAccount();
     $developer = $this->createAccount(MonetizationInterface::DEFAULT_AUTHENTICATED_PERMISSIONS);
 
-    $this->product_bundle = $this->createProductBundle();
-    $this->rate_plan = $this->createRatePlan($this->product_bundle);
-    $this->purchased_plan = $this->createPurchasedPlan($developer, $this->rate_plan);
+    $this->productBundle = $this->createProductBundle();
+    $this->ratePlan = $this->createRatePlan($this->productBundle);
+    $this->purchasedPlan = $this->createPurchasedPlan($developer, $this->ratePlan);
 
-    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
-    $this->field_manager = $this->container->get('entity_field.manager');
+    $this->formatterManager = $this->container->get('plugin.manager.field.formatter');
+    $this->fieldManager = $this->container->get('entity_field.manager');
   }
 
   /**
@@ -101,11 +101,11 @@ class DatestampFormatterKernelTest extends MonetizationKernelTestBase {
   public function testView() {
     $date_format = 'custom';
     $custom_date_format = 'm/d/Y';
-    $item_list = $this->purchased_plan->get('startDate');
+    $item_list = $this->purchasedPlan->get('startDate');
     static::assertInstanceOf(FieldItemList::class, $item_list);
     /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\DatestampFormatter $instance */
-    $instance = $this->formatter_manager->createInstance('apigee_datestamp', [
-      'field_definition' => $this->field_manager->getBaseFieldDefinitions('rate_plan')['startDate'],
+    $instance = $this->formatterManager->createInstance('apigee_datestamp', [
+      'field_definition' => $this->fieldManager->getBaseFieldDefinitions('rate_plan')['startDate'],
       'settings' => [
         'date_format' => $date_format,
         'custom_date_format' => $custom_date_format,
@@ -118,7 +118,7 @@ class DatestampFormatterKernelTest extends MonetizationKernelTestBase {
     static::assertInstanceOf(DatestampFormatter::class, $instance);
 
     /* @var \DateTimeImmutable $value */
-    $value = $this->purchased_plan->getStartDate();
+    $value = $this->purchasedPlan->getStartDate();
     $expected = \Drupal::service('date.formatter')
       ->format($value->getTimestamp(), $date_format, $custom_date_format);
 

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\apigee_m10n\Plugin\Field\FieldFormatter\MonetizationDeveloperFormatter;
+use Drupal\apigee_m10n\Plugin\Field\FieldType\MonetizationDeveloperFieldItem;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+
+/**
+ * Test the `apigee_monetization_developer` field formatter.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBase {
+
+  /**
+   * The formatter manager.
+   *
+   * @var \Drupal\Core\Field\FormatterPluginManager
+   */
+  protected $formatter_manager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $field_manager;
+
+  /**
+   * Test product bundle.
+   *
+   * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
+   */
+  protected $product_bundle;
+
+  /**
+   * Test rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
+   */
+  protected $rate_plan;
+
+  /**
+   * Test purchased rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\PurchasedPlanInterface
+   */
+  protected $purchased_plan;
+
+  /**
+   * Drupal developer user account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $developer;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig([
+      'user',
+    ]);
+
+    // Do not use user 1.
+    $this->createAccount();
+
+    $this->developer = $this->createAccount(MonetizationInterface::DEFAULT_AUTHENTICATED_PERMISSIONS);
+
+    $this->product_bundle = $this->createProductBundle();
+    $this->rate_plan = $this->createRatePlan($this->product_bundle);
+    $this->purchased_plan = $this->createPurchasedPlan($this->developer, $this->rate_plan);
+
+    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
+    $this->field_manager = $this->container->get('entity_field.manager');
+  }
+
+  /**
+   * Test viewing a purchased plan.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function testView() {
+    $item_list = $this->purchased_plan->get('developer');
+    static::assertInstanceOf(FieldItemList::class, $item_list);
+    static::assertInstanceOf(MonetizationDeveloperFieldItem::class, $item_list->get(0));
+    static::assertSame($this->purchased_plan->getDeveloper()->id(), $item_list->get(0)->value->id());
+    /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\MonetizationDeveloperFormatter $instance */
+    $instance = $this->formatter_manager->createInstance('apigee_monetization_developer', [
+      'field_definition' => $this->field_manager->getBaseFieldDefinitions('purchased_plan')['developer'],
+      'settings' => [],
+      'label' => TRUE,
+      'view_mode' => 'default',
+      'third_party_settings' => [],
+    ]);
+    static::assertInstanceOf(MonetizationDeveloperFormatter::class, $instance);
+
+    // Render the field item.
+    $build = $instance->view($item_list);
+
+    static::assertSame('Developer', (string) $build['#title']);
+    static::assertTrue($build['#label_display']);
+    static::assertSame($this->purchased_plan->getDeveloper()->getName(), (string) $build[0]['#markup']);
+
+    $this->render($build);
+    $this->assertText($this->purchased_plan->getDeveloper()->getName());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
@@ -38,35 +38,35 @@ class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBas
    *
    * @var \Drupal\Core\Field\FormatterPluginManager
    */
-  protected $formatter_manager;
+  protected $formatterManager;
 
   /**
    * The entity field manager.
    *
    * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
-  protected $field_manager;
+  protected $fieldManager;
 
   /**
    * Test product bundle.
    *
    * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
    */
-  protected $product_bundle;
+  protected $productBundle;
 
   /**
    * Test rate plan.
    *
    * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
    */
-  protected $rate_plan;
+  protected $ratePlan;
 
   /**
    * Test purchased rate plan.
    *
    * @var \Drupal\apigee_m10n\Entity\PurchasedPlanInterface
    */
-  protected $purchased_plan;
+  protected $purchasedPlan;
 
   /**
    * Drupal developer user account.
@@ -95,12 +95,12 @@ class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBas
 
     $this->developer = $this->createAccount(MonetizationInterface::DEFAULT_AUTHENTICATED_PERMISSIONS);
 
-    $this->product_bundle = $this->createProductBundle();
-    $this->rate_plan = $this->createRatePlan($this->product_bundle);
-    $this->purchased_plan = $this->createPurchasedPlan($this->developer, $this->rate_plan);
+    $this->productBundle = $this->createProductBundle();
+    $this->ratePlan = $this->createRatePlan($this->productBundle);
+    $this->purchasedPlan = $this->createPurchasedPlan($this->developer, $this->ratePlan);
 
-    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
-    $this->field_manager = $this->container->get('entity_field.manager');
+    $this->formatterManager = $this->container->get('plugin.manager.field.formatter');
+    $this->fieldManager = $this->container->get('entity_field.manager');
   }
 
   /**
@@ -110,13 +110,13 @@ class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBas
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   public function testView() {
-    $item_list = $this->purchased_plan->get('developer');
+    $item_list = $this->purchasedPlan->get('developer');
     static::assertInstanceOf(FieldItemList::class, $item_list);
     static::assertInstanceOf(MonetizationDeveloperFieldItem::class, $item_list->get(0));
-    static::assertSame($this->purchased_plan->getDeveloper()->id(), $item_list->get(0)->value->id());
+    static::assertSame($this->purchasedPlan->getDeveloper()->id(), $item_list->get(0)->value->id());
     /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\MonetizationDeveloperFormatter $instance */
-    $instance = $this->formatter_manager->createInstance('apigee_monetization_developer', [
-      'field_definition' => $this->field_manager->getBaseFieldDefinitions('purchased_plan')['developer'],
+    $instance = $this->formatterManager->createInstance('apigee_monetization_developer', [
+      'field_definition' => $this->fieldManager->getBaseFieldDefinitions('purchased_plan')['developer'],
       'settings' => [],
       'label' => TRUE,
       'view_mode' => 'default',
@@ -129,10 +129,10 @@ class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBas
 
     static::assertSame('Developer', (string) $build['#title']);
     static::assertTrue($build['#label_display']);
-    static::assertSame($this->purchased_plan->getDeveloper()->getName(), (string) $build[0]['#markup']);
+    static::assertSame($this->purchasedPlan->getDeveloper()->getName(), (string) $build[0]['#markup']);
 
     $this->render($build);
-    $this->assertText($this->purchased_plan->getDeveloper()->getName());
+    $this->assertText($this->purchasedPlan->getDeveloper()->getName());
   }
 
 }

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/PriceFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/PriceFormatterKernelTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\apigee_m10n\Plugin\Field\FieldFormatter\PriceFormatter;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+
+/**
+ * Test the `apigee_price` field formatter.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class PriceFormatterKernelTest extends MonetizationKernelTestBase {
+
+  /**
+   * The formatter manager.
+   *
+   * @var \Drupal\Core\Field\FormatterPluginManager
+   */
+  protected $formatter_manager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $field_manager;
+
+  /**
+   * Test product bundle.
+   *
+   * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
+   */
+  protected $product_bundle;
+
+  /**
+   * Test rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
+   */
+  protected $rate_plan;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->product_bundle = $this->createProductBundle();
+    $this->rate_plan = $this->createRatePlan($this->product_bundle);
+
+    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
+    $this->field_manager = $this->container->get('entity_field.manager');
+  }
+
+  /**
+   * Test formatter display.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function testView() {
+    $value = '2.0000';
+    $this->rate_plan->setEarlyTerminationFee($value);
+    $settings = [
+      'strip_trailing_zeroes' => FALSE,
+      'currency_display' => 'symbol',
+    ];
+
+    $item_list = $this->rate_plan->get('earlyTerminationFee');
+    static::assertInstanceOf(FieldItemList::class, $item_list);
+    /* @var \Drupal\Core\Field\BaseFieldDefinition $field_definition */
+    $field_definition = $this->field_manager->getBaseFieldDefinitions('rate_plan')['earlyTerminationFee'];
+
+    /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\PriceFormatter $instance */
+    $instance = $this->formatter_manager->createInstance('apigee_price', [
+      'field_definition' => $field_definition,
+      'settings' => $settings,
+      'label' => TRUE,
+      'view_mode' => 'default',
+      'third_party_settings' => [],
+    ]);
+    static::assertInstanceOf(PriceFormatter::class, $instance);
+
+    // Render the field item.
+    $build = $instance->view($item_list);
+
+    static::assertSame((string) $field_definition->getLabel(), (string) $build['#title']);
+    static::assertTrue($build['#label_display']);
+    static::assertSame('$2.00', (string) $build[0]['#markup']);
+
+    $instance->setSetting('strip_trailing_zeroes', TRUE);
+    $build = $instance->view($item_list);
+    static::assertSame('$2', (string) $build[0]['#markup']);
+
+    $instance->setSetting('currency_display', 'code');
+    $build = $instance->view($item_list);
+    static::assertSame('USD2', (string) $build[0]['#markup']);
+
+    $instance->setSetting('currency_display', 'none');
+    $build = $instance->view($item_list);
+    static::assertSame('2', (string) $build[0]['#markup']);
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/PriceFormatterKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/PriceFormatterKernelTest.php
@@ -36,28 +36,28 @@ class PriceFormatterKernelTest extends MonetizationKernelTestBase {
    *
    * @var \Drupal\Core\Field\FormatterPluginManager
    */
-  protected $formatter_manager;
+  protected $formatterManager;
 
   /**
    * The entity field manager.
    *
    * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
-  protected $field_manager;
+  protected $fieldManager;
 
   /**
    * Test product bundle.
    *
    * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
    */
-  protected $product_bundle;
+  protected $productBundle;
 
   /**
    * Test rate plan.
    *
    * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
    */
-  protected $rate_plan;
+  protected $ratePlan;
 
   /**
    * {@inheritdoc}
@@ -65,11 +65,11 @@ class PriceFormatterKernelTest extends MonetizationKernelTestBase {
   protected function setUp() {
     parent::setUp();
 
-    $this->product_bundle = $this->createProductBundle();
-    $this->rate_plan = $this->createRatePlan($this->product_bundle);
+    $this->productBundle = $this->createProductBundle();
+    $this->ratePlan = $this->createRatePlan($this->productBundle);
 
-    $this->formatter_manager = $this->container->get('plugin.manager.field.formatter');
-    $this->field_manager = $this->container->get('entity_field.manager');
+    $this->formatterManager = $this->container->get('plugin.manager.field.formatter');
+    $this->fieldManager = $this->container->get('entity_field.manager');
   }
 
   /**
@@ -80,19 +80,19 @@ class PriceFormatterKernelTest extends MonetizationKernelTestBase {
    */
   public function testView() {
     $value = '2.0000';
-    $this->rate_plan->setEarlyTerminationFee($value);
+    $this->ratePlan->setEarlyTerminationFee($value);
     $settings = [
       'strip_trailing_zeroes' => FALSE,
       'currency_display' => 'symbol',
     ];
 
-    $item_list = $this->rate_plan->get('earlyTerminationFee');
+    $item_list = $this->ratePlan->get('earlyTerminationFee');
     static::assertInstanceOf(FieldItemList::class, $item_list);
     /* @var \Drupal\Core\Field\BaseFieldDefinition $field_definition */
-    $field_definition = $this->field_manager->getBaseFieldDefinitions('rate_plan')['earlyTerminationFee'];
+    $field_definition = $this->fieldManager->getBaseFieldDefinitions('rate_plan')['earlyTerminationFee'];
 
     /** @var \Drupal\apigee_m10n\Plugin\Field\FieldFormatter\PriceFormatter $instance */
-    $instance = $this->formatter_manager->createInstance('apigee_price', [
+    $instance = $this->formatterManager->createInstance('apigee_price', [
       'field_definition' => $field_definition,
       'settings' => $settings,
       'label' => TRUE,

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/ApigeeOrganizationSelectWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/ApigeeOrganizationSelectWidgetKernelTest.php
@@ -41,7 +41,8 @@ class ApigeeOrganizationSelectWidgetKernelTest extends BaseWidgetKernelTest {
       'placeholder' => 'lorem ipsum',
     ];
     $this->createField('node', 'page', $field_name, $field_type, $field_name);
-    entity_get_form_display('node', 'page', 'default')
+    $this->container->get('entity_display.repository')
+      ->getFormDisplay('node', 'page', 'default')
       ->setComponent($field_name, [
         'type' => 'apigee_organization',
         'settings' => $settings,

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/ApigeeOrganizationSelectWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/ApigeeOrganizationSelectWidgetKernelTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldWidget;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test the `apigee_organization` field widget.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class ApigeeOrganizationSelectWidgetKernelTest extends MonetizationKernelTestBase {
+
+  use ContentTypeCreationTrait;
+  use NodeCreationTrait;
+
+  /**
+   * Set to TRUE to strict check all configuration saved.
+   *
+   * @var bool
+   *
+   * @see \Drupal\Core\Config\Testing\ConfigSchemaChecker
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['user', 'system', 'field', 'text', 'filter', 'node'];
+
+  /**
+   * The formatter manager.
+   *
+   * @var \Drupal\Core\Field\FormatterPluginManager
+   */
+  protected $formatter_manager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $field_manager;
+
+  /**
+   * Test product bundle.
+   *
+   * @var \Drupal\apigee_m10n\Entity\ProductBundleInterface
+   */
+  protected $product_bundle;
+
+  /**
+   * Test rate plan.
+   *
+   * @var \Drupal\apigee_m10n\Entity\RatePlanInterface
+   */
+  protected $rate_plan;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installSchema('system', 'sequences');
+    $this->installConfig(['filter', 'node', 'system']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig(['field']);
+
+    // Create a Content type and two test nodes.
+    $this->createContentType(['type' => 'page']);
+    $this->createNode(['title' => 'Test page']);
+    $this->createNode(['title' => 'Page test']);
+
+    $developer = $this->createAccount([
+      'access content',
+      'create page content',
+    ]);
+    $this->setCurrentUser($developer);
+  }
+
+  /**
+   * Test widget display.
+   */
+  public function testView() {
+    $field_name = 'field_test';
+    $settings = [
+      'size' => 30,
+      'placeholder' => 'lorem ipsum',
+    ];
+    $this->createField('node', 'page', $field_name, $field_name);
+    entity_get_form_display('node', 'page', 'default')
+      ->setComponent($field_name, [
+        'type' => 'apigee_organization',
+        'settings' => $settings,
+      ])
+      ->save();
+
+    // Test the node add page for the field widget.
+    $response = $this->container
+      ->get('http_kernel')
+      ->handle(Request::create('node/add/page', 'GET'));
+    $this->setRawContent($response->getContent());
+
+    $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    $element = $this->cssSelect('[name="' . $field_name . '[0][value]"]');
+    $this->assertNotEmpty($element);
+    $element = $element[0];
+    $attributes = (array) $element;
+    $this->assertEquals($settings['size'], $attributes['@attributes']['size']);
+    $this->assertEquals($settings['placeholder'], $attributes['@attributes']['placeholder']);
+  }
+
+  /**
+   * Creates a field on the specified bundle.
+   *
+   * @param string $entity_type
+   *   The type of entity the field will be attached to.
+   * @param string $bundle
+   *   The bundle name of the entity the field will be attached to.
+   * @param string $field_name
+   *   The name of the field.
+   * @param string $field_label
+   *   The label of the field.
+   * @param int $cardinality
+   *   The cardinality of the field.
+   * @param array $settings
+   *   The field settings.
+   */
+  protected function createField($entity_type, $bundle, $field_name, $field_label, $cardinality = 1, $settings = []) {
+    // Look for or add the specified field to the requested entity bundle.
+    if (!FieldStorageConfig::loadByName($entity_type, $field_name)) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'type' => 'apigee_organization',
+        'entity_type' => $entity_type,
+        'cardinality' => $cardinality,
+        'settings' => $settings,
+      ])->save();
+    }
+    if (!FieldConfig::loadByName($entity_type, $bundle, $field_name)) {
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'bundle' => $bundle,
+        'label' => $field_label,
+        'settings' => $settings,
+      ])->save();
+    }
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
@@ -89,8 +89,10 @@ abstract class BaseWidgetKernelTest extends MonetizationKernelTestBase {
    *   The cardinality of the field.
    * @param array $settings
    *   The field settings.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  protected function createField($entity_type, $bundle, $field_name, $field_type, $field_label, $cardinality = 1, $settings = []) {
+  protected function createField($entity_type, $bundle, $field_name, $field_type, $field_label, $cardinality = 1, array $settings = []) {
     // Look for or add the specified field to the requested entity bundle.
     if (!FieldStorageConfig::loadByName($entity_type, $field_name)) {
       FieldStorageConfig::create([

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Plugin\Field\FieldWidget;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Base test class for field widget tests.
+ */
+abstract class BaseWidgetKernelTest extends MonetizationKernelTestBase {
+
+  use ContentTypeCreationTrait;
+  use NodeCreationTrait;
+
+  /**
+   * Set to TRUE to strict check all configuration saved.
+   *
+   * @var bool
+   *
+   * @see \Drupal\Core\Config\Testing\ConfigSchemaChecker
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['user', 'system', 'field', 'text', 'filter', 'node'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installSchema('system', 'sequences');
+    $this->installConfig(['filter', 'node', 'system']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig(['field']);
+
+    // Create a Content type and two test nodes.
+    $this->createContentType(['type' => 'page']);
+    $this->createNode(['title' => 'Test page']);
+    $this->createNode(['title' => 'Page test']);
+
+    $developer = $this->createAccount([
+      'access content',
+      'create page content',
+    ]);
+    $this->setCurrentUser($developer);
+  }
+
+  /**
+   * Creates a field of the given type on the specified entity type/bundle.
+   *
+   * @param string $entity_type
+   *   The type of entity the field will be attached to.
+   * @param string $bundle
+   *   The bundle name of the entity the field will be attached to.
+   * @param string $field_name
+   *   The name of the field.
+   * @param string $field_type
+   *   The field type.
+   * @param string $field_label
+   *   The label of the field.
+   * @param int $cardinality
+   *   The cardinality of the field.
+   * @param array $settings
+   *   The field settings.
+   */
+  protected function createField($entity_type, $bundle, $field_name, $field_type, $field_label, $cardinality = 1, $settings = []) {
+    // Look for or add the specified field to the requested entity bundle.
+    if (!FieldStorageConfig::loadByName($entity_type, $field_name)) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'type' => $field_type,
+        'entity_type' => $entity_type,
+        'cardinality' => $cardinality,
+        'settings' => $settings,
+      ])->save();
+    }
+    if (!FieldConfig::loadByName($entity_type, $bundle, $field_name)) {
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'bundle' => $bundle,
+        'label' => $field_label,
+        'settings' => $settings,
+      ])->save();
+    }
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/BaseWidgetKernelTest.php
@@ -62,8 +62,8 @@ abstract class BaseWidgetKernelTest extends MonetizationKernelTestBase {
 
     // Create a Content type and two test nodes.
     $this->createContentType(['type' => 'page']);
-    $this->createNode(['title' => 'Test page']);
-    $this->createNode(['title' => 'Page test']);
+    $this->createNode(['title' => 'Test page', 'uid' => 0]);
+    $this->createNode(['title' => 'Page test', 'uid' => 0]);
 
     $developer = $this->createAccount([
       'access content',

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/DatestampWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/DatestampWidgetKernelTest.php
@@ -23,19 +23,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Test the `apigee_organization` field widget.
+ * Test the `apigee_datestamp` field widget.
  *
  * @group apigee_m10n
  * @group apigee_m10n_kernel
  */
-class ApigeeOrganizationSelectWidgetKernelTest extends BaseWidgetKernelTest {
+class DatestampWidgetKernelTest extends BaseWidgetKernelTest {
 
   /**
    * Test widget display.
    */
   public function testView() {
     $field_name = 'field_test';
-    $field_type = 'apigee_organization';
+    $field_type = 'apigee_datestamp';
     $settings = [
       'size' => 30,
       'placeholder' => 'lorem ipsum',
@@ -43,7 +43,7 @@ class ApigeeOrganizationSelectWidgetKernelTest extends BaseWidgetKernelTest {
     $this->createField('node', 'page', $field_name, $field_type, $field_name);
     entity_get_form_display('node', 'page', 'default')
       ->setComponent($field_name, [
-        'type' => 'apigee_organization',
+        'type' => 'apigee_datestamp',
         'settings' => $settings,
       ])
       ->save();
@@ -55,12 +55,11 @@ class ApigeeOrganizationSelectWidgetKernelTest extends BaseWidgetKernelTest {
     $this->setRawContent($response->getContent());
 
     $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-    $element = $this->cssSelect('[name="' . $field_name . '[0][value]"]');
+    $element = $this->cssSelect('[name="' . $field_name . '[0][value][date]"]');
     $this->assertNotEmpty($element);
     $element = $element[0];
     $attributes = (array) $element;
-    $this->assertEquals($settings['size'], $attributes['@attributes']['size']);
-    $this->assertEquals($settings['placeholder'], $attributes['@attributes']['placeholder']);
+    $this->assertEquals('date', $attributes['@attributes']['type']);
   }
 
 }

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/DatestampWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/DatestampWidgetKernelTest.php
@@ -38,7 +38,8 @@ class DatestampWidgetKernelTest extends BaseWidgetKernelTest {
     $field_type = 'apigee_datestamp';
     $settings = [];
     $this->createField('node', 'page', $field_name, $field_type, $field_name);
-    entity_get_form_display('node', 'page', 'default')
+    $this->container->get('entity_display.repository')
+      ->getFormDisplay('node', 'page', 'default')
       ->setComponent($field_name, [
         'type' => 'apigee_datestamp',
         'settings' => $settings,

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/TermsAndConditionsWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/TermsAndConditionsWidgetKernelTest.php
@@ -23,24 +23,35 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Test the `apigee_datestamp` field widget.
+ * Test the `apigee_tnc_widget` field widget.
  *
  * @group apigee_m10n
  * @group apigee_m10n_kernel
  */
-class DatestampWidgetKernelTest extends BaseWidgetKernelTest {
+class TermsAndConditionsWidgetKernelTest extends BaseWidgetKernelTest {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->warmTnsCache();
+  }
 
   /**
    * Test widget display.
    */
   public function testView() {
     $field_name = 'field_test';
-    $field_type = 'apigee_datestamp';
-    $settings = [];
+    $field_type = 'apigee_tnc';
+    $settings = [
+      'default_description' => 'lorem ipsum',
+    ];
     $this->createField('node', 'page', $field_name, $field_type, $field_name);
     entity_get_form_display('node', 'page', 'default')
       ->setComponent($field_name, [
-        'type' => 'apigee_datestamp',
+        'type' => 'apigee_tnc_widget',
         'settings' => $settings,
       ])
       ->save();
@@ -52,11 +63,11 @@ class DatestampWidgetKernelTest extends BaseWidgetKernelTest {
     $this->setRawContent($response->getContent());
 
     $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-    $element = $this->cssSelect('[name="' . $field_name . '[0][value][date]"]');
+    $element = $this->cssSelect('[name="' . $field_name . '[0][value]"]');
     $this->assertNotEmpty($element);
     $element = $element[0];
     $attributes = (array) $element;
-    $this->assertEquals('date', $attributes['@attributes']['type']);
+    $this->assertEquals('checkbox', $attributes['@attributes']['type']);
   }
 
 }


### PR DESCRIPTION
Closes #174 . Adds test for custom widgets and formatters:

- MonetizationDeveloperFormatter
- DateAndTextFormatter
- DatestampFormatter
- PriceFormatter
- ApigeeOrganizationSelectWidget
- DatestampWidget
- TermsAndConditionsWidget
