### PR TITLE
Fix circleCI builds

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -50,16 +50,22 @@ class RoboFile extends \Robo\Tasks
         $config->extra->{"patches"} = new \stdClass();
         file_put_contents('composer.json', json_encode($config));
 
-        // Create a directory for our artifacts.
+        // Create directories for our artifacts.
         $this->taskFilesystemStack()
           ->mkdir('artifacts')
-          ->mkdir('artifacts/phpunit')
           ->mkdir('artifacts/phpcs')
           ->mkdir('artifacts/phpmd')
+          ->mkdir('artifacts/coverage-html')
+          ->mkdir('artifacts/coverage-xml')
+          ->mkdir('/tmp/artifacts')
+          ->mkdir('/tmp/artifacts/phpunit')
+          ->mkdir('/tmp/artifacts/phpcs')
+          ->mkdir('/tmp/artifacts/phpmd')
           ->run();
 
         $this->taskFilesystemStack()
           ->chown('artifacts', 'www-data', TRUE)
+          ->chown('/tmp/artifacts', 'www-data', TRUE)
           ->run();
     }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ update_dependencies: &update_dependencies
           - .
 
     - store_artifacts:
-        path: /var/www/html/artifacts
+        path: /tmp/artifacts
 
 # Run Drupal unit and kernel tests as one job. This command invokes the test.sh
 # hook.
@@ -89,13 +89,14 @@ unit_kernel_tests: &unit_kernel_tests
     - run:
         working_directory: /var/www/html
         command: &unit_kernel_tests_command |
+          cp ./modules/apigee_m10n/.circleci/test.sh /var/www/html
           modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
           ./test.sh apigee_m10n
 
     - store_test_results:
-        path: /var/www/html/artifacts/phpunit
+        path: /tmp/artifacts/phpunit
     - store_artifacts:
-        path: /var/www/html/artifacts
+        path: /tmp/artifacts
 
 # Run Drupal functional tests. This command invokes the test-functional.sh
 # hook.
@@ -110,13 +111,14 @@ functional_tests: &functional_tests
     - run:
         working_directory: /var/www/html
         command: &functional_tests_command |
+          cp ./modules/apigee_m10n/.circleci/test-functional.sh /var/www/html
           modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
           ./test-functional.sh apigee_m10n
 
     - store_test_results:
-        path: /var/www/html/artifacts/phpunit
+        path: /tmp/artifacts/phpunit
     - store_artifacts:
-        path: /var/www/html/artifacts
+        path: /tmp/artifacts
 
 # Run Drupal functional tests. This command invokes the test-functional-js.sh
 # hook.
@@ -131,13 +133,14 @@ functional_js_tests: &functional_js_tests
     - run:
         working_directory: /var/www/html
         command: &functional_js_tests_command |
+          cp ./modules/apigee_m10n/.circleci/test-functional-js.sh /var/www/html
           modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
           ./test-functional-js.sh apigee_m10n
 
     - store_test_results:
-        path: /var/www/html/artifacts/phpunit
+        path: /tmp/artifacts/phpunit
     - store_artifacts:
-        path: /var/www/html/artifacts
+        path: /tmp/artifacts
 
 # Run code quality tests. This invokes code-sniffer.sh.
 code_sniffer: &code_sniffer
@@ -203,7 +206,7 @@ all_tests: &all_tests
         command: *functional_js_tests_command
 
     - store_artifacts:
-        path: /var/www/html/artifacts
+        path: /tmp/artifacts
 
 # Declare all of the jobs we should run.
 version: 2

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# CI test-functional-js.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+export MINK_DRIVER_ARGS_WEBDRIVER='["chrome", null, "http://localhost:4444/wd/hub"]'
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+
+# Save artifacts to /tmp directory.
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional-javascript --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+# CI test-functional.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+
+# Save artifacts to /tmp directory.
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+# CI test.sh hook implementation.
+
+export SIMPLETEST_BASE_URL="http://localhost"
+export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
+export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+# This is the command used by the base image to serve Drupal.
+apache2-foreground&
+
+robo override:phpunit-config $1
+
+# Save artifacts to /tmp directory.
+sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite unit,kernel --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml


### PR DESCRIPTION
CircleCI started to have issues with the builds, due to not being able to save the test logs (artifacts) because of directory permissions. An example of a failed build:
https://circleci.com/gh/arlina-espinoza/apigee-m10n-drupal/685 or https://circleci.com/workflow-run/26f0d291-ac34-44fe-9881-b6e25ae13ae3

![image](https://user-images.githubusercontent.com/4062676/66348852-59fad180-e90c-11e9-8323-e15eccac3e24.png)

This PR moves the directories of the tests that were failing into /tmp/artifacts. 

