### PR TITLE
[#215] Fix link to add credit to a prepaid balance

### DIFF
--- a/modules/apigee_m10n_add_credit/src/AddCreditService.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditService.php
@@ -478,7 +478,7 @@ class AddCreditService implements AddCreditServiceInterface {
         'query' => [
           AddCreditConfig::TARGET_FIELD_NAME => [
             'target_type' => $add_credit_type_plugin->getPluginId(),
-            'target_id' => $target_id,
+            'target_id' => $add_credit_type_plugin->getEntityId($add_credit_target),
           ],
         ],
       ]);

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditPrepaidBalancePageTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditPrepaidBalancePageTest.php
@@ -88,6 +88,17 @@ class AddCreditPrepaidBalancePageTest extends AddCreditFunctionalTestBase {
     $this->assertSession()->elementExists('css', '.add-credit--usd.dropbutton');
     $this->assertSession()->elementNotExists('css', '.add-credit--aud.dropbutton');
 
+    // Verify link to add credit, it should contain the developer email.
+    $url = $this->product->toUrl('canonical', [
+      'query' => [
+        AddCreditConfig::TARGET_FIELD_NAME => [
+          'target_type' => 'developer',
+          'target_id' => $this->developer->getEmail(),
+        ],
+      ],
+    ]);
+    $this->assertSession()->linkByHrefExists($url->toString());
+
     // Configure an add credit product for AUD.
     // There should be an add credit button for BOTH usd and aud.
     $this->setAddCreditProductForCurrencyId($this->product, 'aud');


### PR DESCRIPTION
Fixes #215 .
Found an issue where the add credit link was trying to add the credit to the developer by drupal UID instead of by email, so it was failing when querying the API. This PR fixes the link so the job to update the prepaid balance completes successfully.
