### PR TITLE
Compatibility with commerce 8.x-2.16

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -432,7 +432,7 @@ class RoboFile extends \Robo\Tasks
       // TODO Revert this when `andrewberry/drupal_tests` is updated to ~8.7.0.
 
       // We need Drupal\commerce_store\StoreCreationTrait for AddCreditProductAdminTest.php
-      $config->require->{"drupal/commerce"} = "2.13.0";
+      $config->require->{"drupal/commerce"} = "^2.16";
       $config->require->{"drupal/token"} = "~1.0";
 
       // Add dependencies for phpunit tests.

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.info.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.info.yml
@@ -6,7 +6,7 @@ type: module
 core: 8.x
 dependencies:
   - apigee_m10n:apigee_m10n
-  - commerce:commerce (>=8.x-2.12)
+  - commerce:commerce (>=8.x-2.16)
   - commerce:commerce_product
   - commerce:commerce_payment
   - commerce:commerce_price

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/OrderItemAddToCartFormDisplay.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/OrderItemAddToCartFormDisplay.php
@@ -111,7 +111,7 @@ class OrderItemAddToCartFormDisplay extends RequirementBase implements Container
    * {@inheritdoc}
    */
   public function isApplicable(): bool {
-    return $this->getModuleHandler()->moduleExists('apigee_m10n_add_credit');
+    return $this->getModuleHandler()->moduleExists('apigee_m10n_add_credit') && $this->getEntityFormDisplay();
   }
 
   /**
@@ -127,8 +127,14 @@ class OrderItemAddToCartFormDisplay extends RequirementBase implements Container
    * @return \Drupal\Core\Entity\Display\EntityFormDisplayInterface
    *   The entity form display.
    */
-  protected function getEntityFormDisplay(): EntityFormDisplayInterface {
-    return $this->entityDisplayRepository->getFormDisplay('commerce_order_item', 'add_credit', 'add_to_cart');
+  protected function getEntityFormDisplay():? EntityFormDisplayInterface {
+    try {
+      $form_display = $this->entityDisplayRepository->getFormDisplay('commerce_order_item', 'add_credit', 'add_to_cart');
+    }
+    catch (\RuntimeException $e) {
+      return NULL;
+    }
+    return $form_display;
   }
 
   /**


### PR DESCRIPTION
While working on https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/319, I noticed some entity schemas changes of commerce entities, starting from `commerce 8.x-2.16`.
This PR updates the `apigee_m10n_add_credit` module so that it is compatible with the latest Commerce release.
Related: https://www.drupal.org/node/3090561