### PR TITLE
[#228] Allow developers and teams to download revenue reports

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -414,6 +414,9 @@ class RoboFile extends \Robo\Tasks
         "*" => "dist"
       ];
 
+      // Add edge dependencies.
+      $config->require->{"drupal/rules"} = "^3.0@alpha";
+
       // The drupal image contains Drupal core v8.6.x. A request has been made
       // for an updated version.
       // See: <https://github.com/deviantintegral/drupal_tests/issues/55>

--- a/apigee_m10n.links.task.yml
+++ b/apigee_m10n.links.task.yml
@@ -35,6 +35,13 @@ apigee_m10n.profile:
   parent_id: apigee_m10n.balance_and_plans
   weight: 0
 
+apigee_m10n.reports:
+  title: 'Reports'
+  route_name: apigee_monetization.reports
+  base_route: entity.user.canonical
+  parent_id: apigee_m10n.balance_and_plans
+  weight: 10
+
 apigee_m10n.settings.prepaid_balance:
   title: 'Prepaid balance'
   route_name: apigee_m10n.settings.prepaid_balance

--- a/apigee_m10n.permissions.yml
+++ b/apigee_m10n.permissions.yml
@@ -22,6 +22,12 @@ view own billing details:
 view any billing details:
   title: 'View any billing details'
 
+download own reports:
+  title: 'Download own reports'
+
+download any reports:
+  title: 'Download any reports'
+
 view product_bundle:
   title: 'View product bundles'
 

--- a/apigee_m10n.routing.yml
+++ b/apigee_m10n.routing.yml
@@ -110,6 +110,17 @@ apigee_monetization.profile:
   options:
     _apigee_monetization_route: TRUE
 
+apigee_monetization.reports:
+  path: /user/{user}/monetization/reports
+  defaults:
+    _form: \Drupal\apigee_m10n\Form\ReportsDownloadForm
+    _title: Download Reports
+  requirements:
+    user: '^[1-9]+[0-9]*$'
+    _custom_access: \Drupal\apigee_m10n\Form\ReportsDownloadForm::access
+  options:
+    _apigee_monetization_route: TRUE
+
 entity.purchased_plan.developer_collection:
   path: /user/{user}/monetization/purchased-plans
   defaults:

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.links.task.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.links.task.yml
@@ -24,6 +24,13 @@ apigee_m10n_teams.team_billing_details:
   parent_id: apigee_m10n_teams.balance_and_plans
   weight: 0
 
+apigee_m10n_teams.team_reports:
+  title: 'Reports'
+  route_name: apigee_m10n_teams.team_reports
+  base_route: entity.team.canonical
+  parent_id: apigee_m10n_teams.balance_and_plans
+  weight: 10
+
 apigee_m10n_teams.team_plans:
   route_name: apigee_monetization.team_plans
   title: 'Pricing and Plans'

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
@@ -67,3 +67,17 @@ apigee_m10n_teams.team_billing_details:
   options:
     _apigee_monetization_route: TRUE
     _apigee_developer_route: apigee_monetization.profile
+
+apigee_m10n_teams.team_reports:
+  path: '/teams/{team}/monetization/reports'
+  defaults:
+    _form: '\Drupal\apigee_m10n_teams\Form\TeamReportsDownloadForm'
+    _title: 'Download Reports'
+  requirements:
+    _team_permission: 'download reports'
+  options:
+    parameters:
+      team:
+        type: entity:team
+    _apigee_monetization_route: TRUE
+    _apigee_developer_route: apigee_monetization.profile

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
@@ -76,8 +76,5 @@ apigee_m10n_teams.team_reports:
   requirements:
     _team_permission: 'download reports'
   options:
-    parameters:
-      team:
-        type: entity:team
     _apigee_monetization_route: TRUE
     _apigee_developer_route: apigee_monetization.profile

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.team_permissions.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.team_permissions.yml
@@ -9,3 +9,6 @@ view prepaid balance report:
 
 refresh prepaid balance:
   title: 'Refresh prepaid balance'
+
+download reports:
+  title: 'Download reports'

--- a/modules/apigee_m10n_teams/src/Form/TeamReportsDownloadForm.php
+++ b/modules/apigee_m10n_teams/src/Form/TeamReportsDownloadForm.php
@@ -20,12 +20,21 @@
 
 namespace Drupal\apigee_m10n_teams\Form;
 
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_m10n\Form\ReportsDownloadFormBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Defines the reports download form for team.
  */
 class TeamReportsDownloadForm extends ReportsDownloadFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, TeamInterface $team = NULL) {
+    return $this->getForm($form, $form_state, $team);
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/apigee_m10n_teams/src/Form/TeamReportsDownloadForm.php
+++ b/modules/apigee_m10n_teams/src/Form/TeamReportsDownloadForm.php
@@ -18,22 +18,20 @@
  * MA 02110-1301, USA.
  */
 
-namespace Drupal\apigee_m10n\Form;
+namespace Drupal\apigee_m10n_teams\Form;
+
+use Drupal\apigee_m10n\Form\ReportsDownloadFormBase;
 
 /**
- * Defines the reports download form for developer.
+ * Defines the reports download form for team.
  */
-class ReportsDownloadForm extends ReportsDownloadFormBase {
+class TeamReportsDownloadForm extends ReportsDownloadFormBase {
 
   /**
    * {@inheritdoc}
    */
   protected function getEntityId(): string {
-    if ($user = $this->routeMatch->getParameter('user')) {
-      return $this->entityTypeManager->getStorage('user')->load($user)->getEmail();
-    }
-
-    return $this->currentUser->getEmail();
+    return $this->routeMatch->getParameter('team')->id();
   }
 
 }

--- a/src/Form/ReportsDownloadForm.php
+++ b/src/Form/ReportsDownloadForm.php
@@ -20,6 +20,9 @@
 
 namespace Drupal\apigee_m10n\Form;
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\UserInterface;
+
 /**
  * Defines the reports download form for developer.
  */
@@ -28,12 +31,15 @@ class ReportsDownloadForm extends ReportsDownloadFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function getEntityId(): string {
-    if ($user = $this->routeMatch->getParameter('user')) {
-      return $this->entityTypeManager->getStorage('user')->load($user)->getEmail();
-    }
+  public function buildForm(array $form, FormStateInterface $form_state, UserInterface $user = NULL) {
+    return $this->getForm($form, $form_state, $user);
+  }
 
-    return $this->currentUser->getEmail();
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityId(): string {
+    return $this->entity->getEmail();
   }
 
 }

--- a/src/Form/ReportsDownloadForm.php
+++ b/src/Form/ReportsDownloadForm.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Form;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Defines the reports download form for developer.
+ */
+class ReportsDownloadForm extends ReportsDownloadFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface {
+    $user = $route_match->getParameter('user');
+    return AccessResult::allowedIf(
+      $account->hasPermission('download any reports') ||
+      ($account->hasPermission('download own reports') && $account->id() === $user->id())
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityId(): string {
+    if ($user = $this->routeMatch->getParameter('user')) {
+      return $this->entityTypeManager->getStorage('user')->load($user)->getEmail();
+    }
+
+    return $this->currentUser->getEmail();
+  }
+
+}

--- a/src/Form/ReportsDownloadFormBase.php
+++ b/src/Form/ReportsDownloadFormBase.php
@@ -21,9 +21,12 @@
 namespace Drupal\apigee_m10n\Form;
 
 use Apigee\Edge\Exception\ClientErrorException;
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -225,7 +228,13 @@ abstract class ReportsDownloadFormBase extends FormBase {
    * @return \Drupal\Core\Access\AccessResult
    *   Grants access to the route if passed permissions are present.
    */
-//  abstract public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface;
+  public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface {
+    $user = $route_match->getParameter('user');
+    return AccessResult::allowedIf(
+      $account->hasPermission('download any reports') ||
+      ($account->hasPermission('download own reports') && $account->id() === $user->id())
+    );
+  }
 
   /**
    * Returns the entity id for which the report should be generated for.

--- a/src/Form/ReportsDownloadFormBase.php
+++ b/src/Form/ReportsDownloadFormBase.php
@@ -267,6 +267,8 @@ abstract class ReportsDownloadFormBase extends FormBase {
   /**
    * Returns a CSV string for revenue.
    *
+   * TODO: Refactor this to an MonetizationInterface.
+   *
    * @param string $developer_id
    *   The developer id.
    * @param \DateTimeImmutable $from_date

--- a/src/Form/ReportsDownloadFormBase.php
+++ b/src/Form/ReportsDownloadFormBase.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Form;
+
+use Apigee\Edge\Exception\ClientErrorException;
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Defines a base form for reports download.
+ */
+abstract class ReportsDownloadFormBase extends FormBase {
+
+  /**
+   * The Apigee Monetization base service.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * ReportsForm constructor.
+   *
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   The Apigee Monetization base service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(MonetizationInterface $monetization, RouteMatchInterface $route_match, AccountInterface $current_user, EntityTypeManagerInterface $entity_type_manager) {
+    $this->monetization = $monetization;
+    $this->routeMatch = $route_match;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('apigee_m10n.monetization'),
+      $container->get('current_route_match'),
+      $container->get('current_user'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'reports_download_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h3',
+      '#value' => $this->t('Download revenue reports'),
+      '#attributes' => ['class' => ['label']],
+    ];
+
+    // Get supported currencies.
+    $supported_currencies = $this->monetization->getSupportedCurrencies();
+
+    if (empty($supported_currencies)) {
+      $form['currency'] = [
+        '#markup' => $this->t('There are no supported currencies for your account.'),
+      ];
+
+      return $form;
+    }
+
+    // Build currency options.
+    $currency_options = [];
+    /** @var \Apigee\Edge\Api\Monetization\Entity\SupportedCurrencyInterface $currency */
+    foreach ($this->monetization->getSupportedCurrencies() as $currency) {
+      $currency_options[$currency->id()] = "{$currency->getName()} ({$currency->getDisplayName()})";
+    }
+
+    $form['currency'] = [
+      '#title' => $this->t('Select currency'),
+      '#type' => 'select',
+      '#required' => TRUE,
+      '#options' => [
+          '' => $this->t('Select currency'),
+        ] + $currency_options,
+    ];
+
+    $form['from_date'] = [
+      '#title' => $this->t('From date'),
+      '#type' => 'datelist',
+      '#required' => TRUE,
+      '#date_part_order' => ['month', 'day', 'year'],
+      '#date_year_range' => '2010:+',
+      '#default_value' => (new DrupalDateTime())->modify('first day of this month'),
+    ];
+
+    $form['to_date'] = [
+      '#title' => $this->t('To date'),
+      '#type' => 'datelist',
+      '#required' => TRUE,
+      '#date_part_order' => ['month', 'day', 'year'],
+      '#date_year_range' => '2010:+',
+      '#default_value' => new DrupalDateTime(),
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Download report'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $from_date */
+    $from_date = $form_state->getValue('from_date');
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $to_date */
+    $to_date = $form_state->getValue('to_date');
+
+    // Validate date range.
+    if ($from_date->diff($to_date)->invert === 1) {
+      $form_state->setErrorByName('to_date', $this->t('The to date cannot be before the from date.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $currency = $form_state->getValue('currency');
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $from_date */
+    $from_date = $form_state->getValue('from_date');
+    /** @var \Drupal\Core\Datetime\DrupalDateTime $to_date */
+    $to_date = $form_state->getValue('to_date');
+
+    try {
+      if ($report = $this->monetization->getRevenueReport($this->getEntityId(), new \DateTimeImmutable("@{$from_date->getTimestamp()}"), new \DateTimeImmutable("@{$to_date->getTimestamp()}"), $currency)) {
+        $filename = "revenue-report-{$from_date->format('Y-m-d')}-{$to_date->format('Y-m-d')}.csv";
+        $response = new Response($report);
+        $response->headers->set('Content-Type', 'text/csv');
+        $response->headers->set('Content-Disposition', "attachment; filename=$filename");
+        $form_state->setResponse($response);
+      }
+    }
+    catch (ClientErrorException $exception) {
+      $form_state->setRebuild(TRUE);
+      $this->messenger()->addError($this->t('There are no revenue reports for the selected dates.'));
+    }
+  }
+
+  /**
+   * Checks if current user can access reports download.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Grants access to the route if passed permissions are present.
+   */
+//  abstract public function access(RouteMatchInterface $route_match, AccountInterface $account): AccessResultInterface;
+
+  /**
+   * Returns the entity id for which the report should be generated for.
+   *
+   * @return string
+   *   The email of the developer or the name of the team.
+   */
+  abstract protected function getEntityId(): string;
+
+}

--- a/src/Form/ReportsDownloadFormBase.php
+++ b/src/Form/ReportsDownloadFormBase.php
@@ -140,8 +140,8 @@ abstract class ReportsDownloadFormBase extends FormBase {
       '#type' => 'select',
       '#required' => TRUE,
       '#options' => [
-          '' => $this->t('Select currency'),
-        ] + $currency_options,
+        '' => $this->t('Select currency'),
+      ] + $currency_options,
     ];
 
     $form['from_date'] = [
@@ -213,7 +213,8 @@ abstract class ReportsDownloadFormBase extends FormBase {
     }
     catch (ClientErrorException $exception) {
       $form_state->setRebuild(TRUE);
-      $this->messenger()->addError($this->t('There are no revenue reports for the selected dates.'));
+      $this->messenger()
+        ->addError($this->t('There are no revenue reports for the selected dates.'));
     }
   }
 

--- a/src/Monetization.php
+++ b/src/Monetization.php
@@ -26,6 +26,7 @@ use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\TermsAndConditionsInterface;
 use Apigee\Edge\Api\Monetization\Structure\LegalEntityTermsAndConditionsHistoryItem;
 use Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\PrepaidBalanceReportCriteria;
+use Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\RevenueReportCriteria;
 use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
 use Drupal\apigee_edge\SDKConnectorInterface;
@@ -403,6 +404,19 @@ class Monetization implements MonetizationInterface {
   public function getPrepaidBalanceReport(string $developer_id, \DateTimeImmutable $date, string $currency): ?string {
     $controller = $this->sdkControllerFactory->developerReportDefinitionController($developer_id);
     $criteria = new PrepaidBalanceReportCriteria(strtoupper($date->format('F')), (int) $date->format('Y'));
+    $criteria
+      ->developers($developer_id)
+      ->currencies($currency)
+      ->showTransactionDetail(TRUE);
+    return $controller->generateReport($criteria);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRevenueReport(string $developer_id, \DateTimeImmutable $from_date, \DateTimeImmutable $to_date, string $currency): ?string {
+    $controller = $this->sdkControllerFactory->developerReportDefinitionController($developer_id);
+    $criteria = new RevenueReportCriteria($from_date, $to_date);
     $criteria
       ->developers($developer_id)
       ->currencies($currency)

--- a/src/Monetization.php
+++ b/src/Monetization.php
@@ -414,19 +414,6 @@ class Monetization implements MonetizationInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRevenueReport(string $developer_id, \DateTimeImmutable $from_date, \DateTimeImmutable $to_date, string $currency): ?string {
-    $controller = $this->sdkControllerFactory->developerReportDefinitionController($developer_id);
-    $criteria = new RevenueReportCriteria($from_date, $to_date);
-    $criteria
-      ->developers($developer_id)
-      ->currencies($currency)
-      ->showTransactionDetail(TRUE);
-    return $controller->generateReport($criteria);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function isDeveloperAlreadySubscribed(string $developer_id, RatePlanInterface $rate_plan): bool {
     // Use cached result if available.
     // TODO: Handle purchased_plan caching per developer on the storage level.

--- a/src/MonetizationInterface.php
+++ b/src/MonetizationInterface.php
@@ -49,6 +49,7 @@ interface MonetizationInterface {
     'refresh own prepaid balance',
     'download prepaid balance reports',
     'view own billing details',
+    'download own reports',
   ];
 
   /**

--- a/src/MonetizationInterface.php
+++ b/src/MonetizationInterface.php
@@ -153,6 +153,23 @@ interface MonetizationInterface {
   public function getPrepaidBalanceReport(string $developer_id, \DateTimeImmutable $date, string $currency): ?string;
 
   /**
+   * Returns a CSV string for revenue.
+   *
+   * @param string $developer_id
+   *   The developer id.
+   * @param \DateTimeImmutable $from_date
+   *   The from month for the report.
+   * @param \DateTimeImmutable $to_date
+   *   The to month for the report.
+   * @param string $currency
+   *   The currency id. Example: usd.
+   *
+   * @return null|string
+   *   A CSV string of revenue report.
+   */
+  public function getRevenueReport(string $developer_id, \DateTimeImmutable $from_date, \DateTimeImmutable $to_date, string $currency): ?string;
+
+  /**
    * Check if developer accepted latest terms and conditions.
    *
    * @param string $developer_id

--- a/src/MonetizationInterface.php
+++ b/src/MonetizationInterface.php
@@ -154,23 +154,6 @@ interface MonetizationInterface {
   public function getPrepaidBalanceReport(string $developer_id, \DateTimeImmutable $date, string $currency): ?string;
 
   /**
-   * Returns a CSV string for revenue.
-   *
-   * @param string $developer_id
-   *   The developer id.
-   * @param \DateTimeImmutable $from_date
-   *   The from month for the report.
-   * @param \DateTimeImmutable $to_date
-   *   The to month for the report.
-   * @param string $currency
-   *   The currency id. Example: usd.
-   *
-   * @return null|string
-   *   A CSV string of revenue report.
-   */
-  public function getRevenueReport(string $developer_id, \DateTimeImmutable $from_date, \DateTimeImmutable $to_date, string $currency): ?string;
-
-  /**
    * Check if developer accepted latest terms and conditions.
    *
    * @param string $developer_id

--- a/tests/modules/apigee_mock_client/tests/response-templates/post-revenue-reports.csv.twig
+++ b/tests/modules/apigee_mock_client/tests/response-templates/post-revenue-reports.csv.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ *   POST /v1/mint/organizations/{org}/revenue-reports
+ *
+ * Response Code: 200
+ */
+#}
+Reporting Period:,From:,{{ from|default('2018-09-01') }},  To:,{{ to|default('2018-09-30') }}
+API Product:,All
+Developer:,{{ developer|default('Doe, John') }},
+Application:,{{ application|default('All') }}
+Currency:,{{ currency|default('Local') }}
+Type of Report:,Detailed Revenue Report
+
+Monetization Package,Package ID,Rate Plan,Plan ID,API Product,Product ID,Developer Name,Developer ID,Application Name,Application ID,Currency,Transaction Type,Provider Status,Charged Rate,Transaction ID,Payment Reference,Transaction Start Time,Transaction End Time,Batch Size,
+Balance Top-up,,N/A,,N/A,,{{ developer|default('Doe, John') }},5da6ba14-71aa-4efb-ac33-2b4cff161487,N/A,,USD,BALANCE,SUCCESS,-22.0000,f99399b0-22ec-4992-8a91-a8cdac303616,f99399b0-22ec-4992-8a91-a8cdac303616,2020-04-28 06:55:19,2020-04-28 06:55:19,1,
+

--- a/tests/src/Kernel/Access/AccessKernelTest.php
+++ b/tests/src/Kernel/Access/AccessKernelTest.php
@@ -135,6 +135,7 @@ class AccessKernelTest extends MonetizationKernelTestBase {
     $this->assertRatePlanRoutes();
     $this->assertPurchasedPlanRoutes();
     $this->assertBillingRoutes();
+    $this->assertReportsRoute();
   }
 
   /**
@@ -331,6 +332,27 @@ class AccessKernelTest extends MonetizationKernelTestBase {
   }
 
   /**
+   * Tests permissions for billing routes.
+   */
+  public function assertReportsRoute() {
+    // Own reports.
+    $prepaid_balance_url = Url::fromRoute('apigee_monetization.reports', [
+      'user' => $this->developer->id(),
+    ]);
+    static::assertTrue($prepaid_balance_url->access($this->administrator));
+    static::assertTrue($prepaid_balance_url->access($this->developer));
+    static::assertFalse($prepaid_balance_url->access($this->anonymous));
+
+    // Any reports.
+    $prepaid_balance_url = Url::fromRoute('apigee_monetization.reports', [
+      'user' => $this->administrator->id(),
+    ]);
+    static::assertTrue($prepaid_balance_url->access($this->administrator));
+    static::assertFalse($prepaid_balance_url->access($this->developer));
+    static::assertFalse($prepaid_balance_url->access($this->anonymous));
+  }
+
+  /**
    * Tests that the permission list is correct.
    */
   public function assertPermissionList() {
@@ -370,6 +392,8 @@ class AccessKernelTest extends MonetizationKernelTestBase {
       'view rate_plan as anyone' => 'View rate plans as any developer',
       'purchase rate_plan' => 'Purchase a rate plan',
       'purchase rate_plan as anyone' => 'Purchase a rate plan as any developer',
+      'download any reports' => 'Download any reports',
+      'download own reports' => 'Download own reports',
     ];
 
     // Sort both for comparison.

--- a/tests/src/Kernel/Form/ReportsDownloadFormTest.php
+++ b/tests/src/Kernel/Form/ReportsDownloadFormTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_m10n\Kernel\Form;
+
+use Apigee\Edge\Api\Monetization\Entity\SupportedCurrency;
+use Drupal\apigee_m10n\Form\ReportsDownloadForm;
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\apigee_m10n\Kernel\MonetizationKernelTestBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests the reports download form.
+ *
+ * @group apigee_m10n
+ * @group apigee_m10n_kernel
+ */
+class ReportsDownloadFormTest extends MonetizationKernelTestBase {
+
+  /**
+   * Drupal user with access.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $developer;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig([
+      'user',
+      'system',
+    ]);
+
+    $this->warmOrganizationCache();
+    $this->createAccount([]);
+    $this->developer = $this->createAccount([
+      'download own reports',
+    ]);
+  }
+
+  /**
+   * Test the form.
+   */
+  public function testForm() {
+    $this->queueSupportedCurrenciesResponse();
+
+    /** @var \Drupal\Core\Form\FormBuilderInterface $builder */
+    $builder = \Drupal::service('form_builder');
+    /** @var \Drupal\apigee_m10n\Form\ReportsDownloadForm $form */
+    $form = $builder->getForm(ReportsDownloadForm::class, $this->developer);
+
+    // Assert entity.
+    static::assertEquals($this->developer->getEmail(), $form['entity_id']['#value']);
+
+    // Assert currencies.
+    $currency_options = $form['currency']['#options'];
+    static::assertCount(3, $currency_options);
+    static::assertTrue(!empty($currency_options['usd']));
+    static::assertTrue(!empty($currency_options['aud']));
+
+    // Test form validation.
+    $this->queueSupportedCurrenciesResponse();
+    $form_state = new FormState();
+    $form_state->setValue('currency', 'usd');
+    $form_state->setValue('from_date', [
+      'month' => '12',
+      'day' => '27',
+      'year' => '2017',
+    ]);
+    $form_state->setValue('to_date', [
+      'month' => '11',
+      'day' => '27',
+      'year' => '2017',
+    ]);
+    $builder->submitForm(ReportsDownloadForm::class, $form_state, $this->developer);
+    $form_errors = $form_state->getErrors();
+    static::assertEquals('The to date cannot be before the from date.', (string) $form_errors['to_date']);
+
+    // Test form submission.
+    $this->queueSupportedCurrenciesResponse();
+    $this->stack->queueMockResponse([
+      'post-revenue-reports.csv.twig',
+    ]);
+    $form_state = new FormState();
+    $form_state->setValue('currency', 'usd');
+    $form_state->setValue('from_date', [
+      'month' => "12",
+      "day" => "3",
+      "year" => "2017",
+    ]);
+    $form_state->setValue('to_date', [
+      'month' => "12",
+      "day" => "27",
+      "year" => "2017",
+    ]);
+    $builder->submitForm(ReportsDownloadForm::class, $form_state, $this->developer);
+    /** @var \Symfony\Component\HttpFoundation\Response $response */
+    $response = $form_state->getResponse();
+    static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    static::assertEquals('attachment; filename=revenue-report-2017-12-03-2017-12-27.csv', $response->headers->get('content-disposition'));
+    static::assertNotEmpty($response->getContent());
+  }
+
+  /**
+   * Helper to queue supported currencies response.
+   */
+  protected function queueSupportedCurrenciesResponse() {
+    $this->stack->queueMockResponse([
+      'get_supported_currencies' => [
+        'currencies' => [
+          new SupportedCurrency([
+            "description" => "United States Dollars",
+            "displayName" => "United States Dollars",
+            "id" => "usd",
+            "minimumTopupAmount" => 11.0000,
+            "name" => "USD",
+            "status" => "ACTIVE",
+            "virtualCurrency" => FALSE,
+          ]),
+          new SupportedCurrency([
+            "description" => "Australia Dollars",
+            "displayName" => "Australia Dollars",
+            "id" => "aud",
+            "minimumTopupAmount" => 10.0000,
+            "name" => "AUD",
+            "status" => "ACTIVE",
+            "virtualCurrency" => FALSE,
+          ]),
+        ],
+      ],
+    ]);
+  }
+
+}


### PR DESCRIPTION
Fixes #228 

This PR adds functionality to allow developers and teams to generate (csv) revenue reports.

![Download_Reports___Apigee](https://user-images.githubusercontent.com/124599/82043418-9bcad200-96bc-11ea-96db-62b8f1b468a6.jpg)
