### PR TITLE
[#245] Add D9 deprecations check step in CI

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -189,24 +189,24 @@ class RoboFile extends \Robo\Tasks
         ->run();
 
       // Composer often runs out of memory when installing drupal.
-      $this->taskComposerUpdate('php -d memory_limit=-1 /usr/local/bin/composer')
+      $this->taskComposerInstall('php -d memory_limit=-1 /usr/local/bin/composer')
         ->optimizeAutoloader()
         ->run();
 
       // Preserve composer.lock as an artifact for future debugging.
       $this->taskFilesystemStack()
-        ->copy('composer.json', 'artifacts/composer.json')
-        ->copy('composer.lock', 'artifacts/composer.lock')
+        ->copy('composer.json', '/tmp/artifacts/composer.json')
+        ->copy('composer.lock', '/tmp/artifacts/composer.lock')
         ->run();
 
       // Write drush status results to an artifact file.
-      $this->taskExec('vendor/bin/drush status > artifacts/core-stats.txt')
+      $this->taskExec('vendor/bin/drush status > /tmp/artifacts/core-stats.txt')
         ->run();
-      $this->taskExec('cat artifacts/core-stats.txt')
+      $this->taskExec('cat /tmp/artifacts/core-stats.txt')
         ->run();
 
       // Add php info to an artifact file.
-      $this->taskExec('php -i > artifacts/phpinfo.txt')->run();
+      $this->taskExec('php -i > /tmp/artifacts/phpinfo.txt')->run();
 
       // Add composer version info to an artifact file.
       $this->taskExec('composer show')

--- a/.circleci/code-sniffer.sh
+++ b/.circleci/code-sniffer.sh
@@ -14,4 +14,4 @@ vendor/bin/phpmd modules/$1/src html cleancode,codesize,design,unusedcode --igno
 vendor/bin/phpmetrics --extensions=php,inc,module --report-html=artifacts/phpmetrics --git modules/$1
 
 # Check coding standards
-vendor/bin/phpcs -p -s -n --colors --standard=modules/apigee_edge/phpcs.xml.dist --report=junit --report-junit=artifacts/phpcs/phpcs.xml modules/$1
+vendor/bin/phpcs -p -s -n --colors --standard=modules/$1/phpcs.xml.dist --report=junit --report-junit=artifacts/phpcs/phpcs.xml modules/$1

--- a/.circleci/code-sniffer.sh
+++ b/.circleci/code-sniffer.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# Runs CodeSniffer checks on a Drupal module.
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+# Install dependencies and configure phpcs
+vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
+
+vendor/bin/phpmd modules/$1/src html cleancode,codesize,design,unusedcode --ignore-violations-on-exit --reportfile artifacts/phpmd/index.html
+vendor/bin/phpmetrics --extensions=php,inc,module --report-html=artifacts/phpmetrics --git modules/$1
+
+# Check coding standards
+vendor/bin/phpcs -p -s -n --colors --standard=modules/apigee_edge/phpcs.xml.dist --report=junit --report-junit=artifacts/phpcs/phpcs.xml modules/$1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ code_sniffer: &code_sniffer
     - run:
         working_directory: /var/www/html
         command: &code_sniffer_command |
-          cp ./modules/apigee_edge/.circleci/code-sniffer.sh /var/www/html
+          cp ./modules/apigee_m10n/.circleci/code-sniffer.sh /var/www/html
           ./code-sniffer.sh apigee_m10n
 
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,16 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 
+version: 2.1
+
 defaults: &defaults
   docker:
     # specify the version you desire here (avoid latest except for testing)
-    - image: andrewberry/drupal_tests:0.4.0
+    - image: quay.io/deviantintegral/drupal_tests:0.5.0-drupal87
 
     - image: selenium/standalone-chrome-debug:3.14.0-beryllium
 
-    - image: mariadb:10.3
+    - image: mariadb:10.4
       environment:
         MYSQL_ALLOW_EMPTY_PASSWORD: 1
 
@@ -33,6 +35,11 @@ defaults: &defaults
   # circleci CLI tool.
   # https://discuss.circleci.com/t/bug-circleci-build-command-ignores-checkout-path-config/13004
   working_directory: /var/www/html/modules/apigee_m10n
+
+  parameters:
+    core-version:
+      type: integer
+      default: 8
 
 # YAML does not support merging of lists. That means we can't have a default
 # 'steps' configuration, though we can have defaults for individual step
@@ -57,14 +64,18 @@ save_cache: &save_cache
 # composer patches.
 update_dependencies: &update_dependencies
   <<: *defaults
+
   steps:
+    - print:
+        message: Using Drupal core version << parameters.core-version >>
+
     - checkout
 
     - restore_cache: *restore_cache
 
     - run:
         working_directory: /var/www/html
-        command: modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
+        command: modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n << parameters.core-version >>
 
     - save_cache: *save_cache
 
@@ -92,8 +103,8 @@ unit_kernel_tests: &unit_kernel_tests
         working_directory: /var/www/html
         command: &unit_kernel_tests_command |
           cp ./modules/apigee_m10n/.circleci/test.sh /var/www/html
-          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
-          ./test.sh apigee_m10n
+          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n << parameters.core-version >>
+          ./test.sh apigee_m10n << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit
@@ -116,8 +127,8 @@ functional_tests: &functional_tests
         working_directory: /var/www/html
         command: &functional_tests_command |
           cp ./modules/apigee_m10n/.circleci/test-functional.sh /var/www/html
-          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
-          ./test-functional.sh apigee_m10n
+          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n << parameters.core-version >>
+          ./test-functional.sh apigee_m10n << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit
@@ -140,8 +151,8 @@ functional_js_tests: &functional_js_tests
         working_directory: /var/www/html
         command: &functional_js_tests_command |
           cp ./modules/apigee_m10n/.circleci/test-functional-js.sh /var/www/html
-          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
-          ./test-functional-js.sh apigee_m10n
+          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n << parameters.core-version >>
+          ./test-functional-js.sh apigee_m10n << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit
@@ -160,11 +171,8 @@ code_sniffer: &code_sniffer
     - run:
         working_directory: /var/www/html
         command: &code_sniffer_command |
-          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n
-          vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
-          vendor/bin/phpmd modules/apigee_m10n/src html cleancode,codesize,design,unusedcode --ignore-violations-on-exit --reportfile artifacts/phpmd/index.html
-          vendor/bin/phpmetrics --extensions=php,inc,module --report-html=artifacts/phpmetrics --git modules/apigee_m10n
-          vendor/bin/phpcs -s -n --colors --standard=modules/apigee_m10n/phpcs.xml.dist --report=junit --report-junit=artifacts/phpcs/phpcs.xml modules/apigee_m10n
+          cp ./modules/apigee_edge/.circleci/code-sniffer.sh /var/www/html
+          ./code-sniffer.sh apigee_m10n
 
     - store_test_results:
         path: /var/www/html/artifacts/phpcs
@@ -188,6 +196,25 @@ code_coverage: &code_coverage
           ./code-coverage-stats.sh apigee_m10n
     - store_artifacts:
         path: /var/www/html/artifacts
+
+# Run D9 deprecation checks.
+d9_check: &d9_check
+  <<: *defaults
+  steps:
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          ./d9.sh modules/apigee_m10n
+
+    - store_test_results:
+        path: /var/www/html/artifacts/d9
+    - store_artifacts:
+        path: /var/www/html/artifacts/d9
 
 # Run all tests.
 all_tests: &all_tests
@@ -214,8 +241,15 @@ all_tests: &all_tests
     - store_artifacts:
         path: /tmp/artifacts
 
+commands:
+  print:
+    parameters:
+      message:
+        type: string
+    steps:
+      - run: echo << parameters.message >>
+
 # Declare all of the jobs we should run.
-version: 2
 jobs:
   update-dependencies:
      <<: *update_dependencies
@@ -231,6 +265,8 @@ jobs:
      <<: *code_sniffer
   run-code-coverage:
      <<: *code_coverage
+  run-d9-check:
+    <<: *d9_check
 
 workflows:
   version: 2
@@ -238,20 +274,36 @@ workflows:
   # Declare a workflow that runs all of our jobs in parallel.
   test_and_lint:
     jobs:
-      - update-dependencies
+      - update-dependencies:
+          name: update-dependencies-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [ 8 ]
       - run-unit-kernel-tests:
+          name: run-unit-kernel-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [ 8 ]
           requires:
-            - update-dependencies
+            - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
+          name: run-functional-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [ 8 ]
           requires:
-            - update-dependencies
+            - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
+          name: run-functional-js-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [ 8 ]
           requires:
-            - update-dependencies
+            - update-dependencies-<< matrix.core-version >>
       - run-code-sniffer:
           requires:
-            - update-dependencies
+            - update-dependencies-8
       - run-code-coverage:
           requires:
-            - update-dependencies
-            - run-unit-kernel-tests
+            - update-dependencies-8
+            - run-unit-kernel-tests-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,9 @@ workflows:
       - run-code-sniffer:
           requires:
             - update-dependencies-8
+      - run-d9-check:
+          requires:
+            - update-dependencies-8
       - run-code-coverage:
           requires:
             - update-dependencies-8

--- a/.circleci/d9.sh
+++ b/.circleci/d9.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+vendor/bin/drupal-check --no-progress --memory-limit=1000M --format=junit $1 > /var/www/html/artifacts/d9/d9check.xml
+

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -9,7 +9,7 @@ export MINK_DRIVER_ARGS_WEBDRIVER='["chrome", null, "http://localhost:4444/wd/hu
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -8,7 +8,7 @@ export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,7 +8,7 @@ export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -7,6 +7,7 @@ cp modules/apigee_m10n/.circleci/RoboFile.php ./
 if [[ ! -f dependencies_updated ]]; then
   robo setup:skeleton
   robo add:modules $1
+  robo drupal:version $2
   robo configure:m10n-dependencies
   robo update:dependencies
 fi

--- a/apigee_m10n.services.yml
+++ b/apigee_m10n.services.yml
@@ -47,13 +47,13 @@ services:
     class: Drupal\apigee_m10n\Entity\ParamConverter\RatePlanConverter
     tags:
       - { name: paramconverter }
-    arguments: ['@entity_type.manager', '@language_manager']
+    arguments: ['@entity_type.manager', '@entity.repository']
 
   paramconverter.entity.purchased_plan:
     class: Drupal\apigee_m10n\Entity\ParamConverter\PurchasedPlanConverter
     tags:
       - { name: paramconverter }
-    arguments: ['@entity_type.manager', '@language_manager']
+    arguments: ['@entity_type.manager', '@entity.repository']
 
   apigee_m10n.route_subscriber:
     class: Drupal\apigee_m10n\Routing\MonetizationRouteSubscriber

--- a/apigee_m10n.services.yml
+++ b/apigee_m10n.services.yml
@@ -47,13 +47,13 @@ services:
     class: Drupal\apigee_m10n\Entity\ParamConverter\RatePlanConverter
     tags:
       - { name: paramconverter }
-    arguments: ['@entity.manager', '@language_manager']
+    arguments: ['@entity_type.manager', '@language_manager']
 
   paramconverter.entity.purchased_plan:
     class: Drupal\apigee_m10n\Entity\ParamConverter\PurchasedPlanConverter
     tags:
       - { name: paramconverter }
-    arguments: ['@entity.manager', '@language_manager']
+    arguments: ['@entity_type.manager', '@language_manager']
 
   apigee_m10n.route_subscriber:
     class: Drupal\apigee_m10n\Routing\MonetizationRouteSubscriber

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,14 @@
         "apigee/apigee-client-php": "~2.0.3"
     },
     "require-dev": {
-        "behat/mink-extension": "v2.2",
-        "behat/mink-selenium2-driver": "1.3.x-dev",
+        "behat/mink-extension": "^2.0",
         "bex/behat-screenshot": "^1.2",
-        "consolidation/robo": "~1.0",
-        "drupal/coder": "^8.3",
+        "drupal/core-dev": "^8.7 || ^9",
         "drupal/drupal-extension": "master-dev",
-        "phpmd/phpmd": "^2.6",
-        "phpmetrics/phpmetrics": "^2.4",
-        "phpunit/phpunit": "^6.5"
+        "drush/drush": "^9.0 || ^10.0",
+        "phpmd/phpmd": "2.8.2",
+        "phpmetrics/phpmetrics": "^2.5",
+        "mglaman/drupal-check": "^1.1"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
         "drupal/apigee_edge": "~1.10",
+        "drupal/core": "^8 || ^9",
         "drupal/requirement": "~1.0",
         "apigee/apigee-client-php": "~2.0.3"
     },

--- a/modules/apigee_m10n_add_credit/src/AddCreditService.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditService.php
@@ -19,7 +19,6 @@
 
 namespace Drupal\apigee_m10n_add_credit;
 
-use Drupal;
 use Drupal\apigee_m10n\Entity\Form\PurchasedPlanForm;
 use Drupal\apigee_m10n\Entity\PurchasedPlanInterface;
 use Drupal\apigee_m10n_add_credit\Form\AddCreditAddToCartForm;
@@ -345,7 +344,7 @@ class AddCreditService implements AddCreditServiceInterface {
 
     // Show links to "Add credit" even if no current balances in all or
     // some currencies.
-    $currencies = Drupal::service('commerce_price.currency_repository')->getAll();
+    $currencies = \Drupal::service('commerce_price.currency_repository')->getAll();
     foreach ($currencies as $currency) {
       $currency_id = strtolower($currency->getCurrencyCode());
       if (empty($build['table']['#rows'][$currency_id])) {
@@ -518,14 +517,14 @@ class AddCreditService implements AddCreditServiceInterface {
       $add_credit_items = [];
       /** @var \Drupal\commerce_order\Entity\OrderItemInterface $item */
       foreach ($flow->getOrder()->getItems() as $item) {
-        if (Drupal::service('apigee_m10n_add_credit.product_manager')->isProductAddCreditEnabled($item->getPurchasedEntity()->getProduct())) {
+        if (\Drupal::service('apigee_m10n_add_credit.product_manager')->isProductAddCreditEnabled($item->getPurchasedEntity()->getProduct())) {
           $add_credit_items[] = $item;
         }
       }
 
       if (count($add_credit_items)) {
         /** @var \Apigee\Edge\Api\Monetization\Entity\SupportedCurrencyInterface[] $supported_currencies */
-        $supported_currencies = Drupal::service('apigee_m10n.monetization')
+        $supported_currencies = \Drupal::service('apigee_m10n.monetization')
           ->getSupportedCurrencies();
 
         // Validate the total for order item against the minimum top up amount.
@@ -540,7 +539,7 @@ class AddCreditService implements AddCreditServiceInterface {
           ) {
             $form_state->setErrorByName('review', t('The minimum top up amount is @amount @currency_code.', [
               '@currency_code' => $supported_currency->getName(),
-              '@amount' => Drupal::service('commerce_price.currency_formatter')->format($minimum_top_up_amount, $supported_currency->getName(), [
+              '@amount' => \Drupal::service('commerce_price.currency_formatter')->format($minimum_top_up_amount, $supported_currency->getName(), [
                 'currency_display' => 'symbol',
               ]),
             ]));
@@ -627,7 +626,7 @@ class AddCreditService implements AddCreditServiceInterface {
   public static function help($route_name, RouteMatchInterface $route_match) {
     if ($route_name === 'apigee_m10n_add_credit.settings.add_credit') {
       return '<p>' . t('Review the %module module requirements in the <a href=":requirements">Requirements report</a>.', [
-        '%module' => Drupal::moduleHandler()->getName('apigee_m10n_add_credit'),
+        '%module' => \Drupal::moduleHandler()->getName('apigee_m10n_add_credit'),
         ':requirements' => Url::fromRoute('requirement.report')->toString(),
       ]) . '</p>';
     }

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditPrepaidBalanceButtonTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditPrepaidBalanceButtonTest.php
@@ -70,7 +70,7 @@ class AddCreditPrepaidBalanceButtonTest extends AddCreditFunctionalJavascriptTes
     $this->product = $this->createCommerceProduct($this->createCommerceStore(), $variation);
 
     // Enable the add credit target field on the add to cart form.
-    $this->container->get('entity.manager')
+    $this->container->get('entity_type.manager')
       ->getStorage('entity_form_display')
       ->load('commerce_order_item.default.add_to_cart')
       ->setComponent(AddCreditConfig::TARGET_FIELD_NAME, [

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
@@ -219,7 +219,7 @@ class BalanceAdjustmentJobKernelTest extends MonetizationKernelTestBase {
       ])
       ->queueMockResponse([
         'post-prepaid-balance-reports.csv.twig',
-      ]);;
+      ]);
 
     // Execute the job which will update the developer balance.
     $this->getExecutor()->call($job);

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/EntityReferenceSelection/AddCreditProductsSelectionTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/Plugin/EntityReferenceSelection/AddCreditProductsSelectionTest.php
@@ -111,7 +111,7 @@ class AddCreditProductsSelectionTest extends MonetizationKernelTestBase {
       'target_bundles' => NULL,
     ];
 
-    $this->selectionHandler = new AddCreditProductsSelection($configuration, NULL, NULL, \Drupal::entityManager(), \Drupal::moduleHandler(), \Drupal::currentUser());
+    $this->selectionHandler = new AddCreditProductsSelection($configuration, NULL, NULL, \Drupal::entityTypeManager(), \Drupal::moduleHandler(), \Drupal::currentUser());
   }
 
   /**

--- a/modules/apigee_m10n_teams/src/Entity/ParamConverter/TeamPurchasedPlanConverter.php
+++ b/modules/apigee_m10n_teams/src/Entity/ParamConverter/TeamPurchasedPlanConverter.php
@@ -37,7 +37,7 @@ class TeamPurchasedPlanConverter extends PurchasedPlanConverter {
   public function convert($value, $definition, $name, array $defaults) {
     $entity_type_id = $this->getEntityTypeFromDefaults($definition, $name, $defaults);
     /** @var \Drupal\apigee_m10n_teams\Entity\Storage\TeamPurchasedPlanStorage $storage */
-    $storage = $this->entityManager->getStorage($entity_type_id);
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
 
     // Get the team ID.
     $team = $defaults['team'] ?? NULL;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,7 +25,8 @@
   <rule ref="Drupal.Commenting.FunctionComment.TypeHintMissing">
     <severity>0</severity>
   </rule>
-  <rule ref="Drupal.Commenting.GenderNeutralComment.GenderNeutral">
+  <!-- Ignore long array declaration lines. -->
+  <rule ref="Drupal.Arrays.Array.LongLineDeclaration">
     <severity>0</severity>
   </rule>
 

--- a/src/Entity/Form/PurchasedPlanForm.php
+++ b/src/Entity/Form/PurchasedPlanForm.php
@@ -151,7 +151,7 @@ class PurchasedPlanForm extends FieldableEdgeEntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
     // Redirect to Rate Plan detail page on submit.
-    $form['#action'] = $this->getEntity()->getRatePlan()->url('purchase');
+    $form['#action'] = $this->getEntity()->getRatePlan()->toUrl('purchase')->toString();
     return $this->conflictForm($form, $form_state);
   }
 

--- a/src/Entity/ParamConverter/PurchasedPlanConverter.php
+++ b/src/Entity/ParamConverter/PurchasedPlanConverter.php
@@ -73,7 +73,7 @@ class PurchasedPlanConverter extends EntityConverter implements ParamConverterIn
    */
   protected function loadPurchasedPlanById($developer_id, $purchased_plan_id) {
     try {
-      $purchased_plan = $this->entityManager
+      $purchased_plan = $this->entityTypeManager
         ->getStorage('purchased_plan')
         ->loadById($developer_id, $purchased_plan_id);
     }

--- a/tests/src/Kernel/ModuleInstallKernelTest.php
+++ b/tests/src/Kernel/ModuleInstallKernelTest.php
@@ -19,7 +19,6 @@
 
 namespace Drupal\Tests\apigee_m10n\Kernel;
 
-use Drupal;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
@@ -61,7 +60,7 @@ class ModuleInstallKernelTest extends KernelTestBase {
     $this->installSchema('system', ['sequences']);
 
     // Install the user module.
-    Drupal::service('module_installer')->install(['user', 'apigee_edge']);
+    \Drupal::service('module_installer')->install(['user', 'apigee_edge']);
 
     // Create an admin user.
     $this->admin = $this->createUser([], NULL, TRUE);
@@ -77,7 +76,7 @@ class ModuleInstallKernelTest extends KernelTestBase {
    * installed at the same time.
    */
   public function testModuleInstall() {
-    Drupal::service('module_installer')->install(['apigee_m10n']);
+    \Drupal::service('module_installer')->install(['apigee_m10n']);
     // Installing modules updates the container and needs a router rebuild.
     $this->container = \Drupal::getContainer();
     $this->container->get('router.builder')->rebuildIfNeeded();
@@ -104,7 +103,7 @@ class ModuleInstallKernelTest extends KernelTestBase {
     }
 
     // Test uninstalling the monetization module.
-    Drupal::service('module_installer')->uninstall(['apigee_m10n']);
+    \Drupal::service('module_installer')->uninstall(['apigee_m10n']);
   }
 
 }

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/TermsAndConditionsWidgetKernelTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/TermsAndConditionsWidgetKernelTest.php
@@ -49,7 +49,8 @@ class TermsAndConditionsWidgetKernelTest extends BaseWidgetKernelTest {
       'default_description' => 'lorem ipsum',
     ];
     $this->createField('node', 'page', $field_name, $field_type, $field_name);
-    entity_get_form_display('node', 'page', 'default')
+    \Drupal::service('entity_display.repository')
+      ->getFormDisplay('node', 'page', 'default')
       ->setComponent($field_name, [
         'type' => 'apigee_tnc_widget',
         'settings' => $settings,

--- a/tests/src/Kernel/TestFrameworkKernelTest.php
+++ b/tests/src/Kernel/TestFrameworkKernelTest.php
@@ -163,7 +163,6 @@ class TestFrameworkKernelTest extends MonetizationKernelTestBase {
     static::assertNotEmpty($user->getEmail());
     static::assertNotEmpty($user->getDisplayName());
     static::assertNotEmpty($user->getAccountName());
-    static::assertNotEmpty($user->getUsername());
   }
 
 }


### PR DESCRIPTION
Adds deprecations check step in CI, and makes sure all tests are passing, updating as needed. It also brings the circleCI config and related files in sync with that we have in apigee_edge.