### PR TITLE
Resolves #278 - Change heading variable for buy API to reflect the product name

### DIFF
--- a/config/install/core.entity_view_display.xrate_plan.xrate_plan.teaser.yml
+++ b/config/install/core.entity_view_display.xrate_plan.xrate_plan.teaser.yml
@@ -14,7 +14,7 @@ content:
     type: entity_reference_label
     weight: 0
     region: content
-    label: visually_hidden
+    label: hidden
     settings:
       link: false
     third_party_settings: {  }

--- a/templates/apigee-entity--xrate-plan.html.twig
+++ b/templates/apigee-entity--xrate-plan.html.twig
@@ -14,14 +14,23 @@
   {% block content %}
     {{ title_prefix }}
     {%- if label and view_mode != 'full' -%}
+    {% set apiproductName = content.apiProduct|render|striptags %}
+
       <h2{{ title_attributes }}>
-        <a href="{{ url }}">{{ label }}</a>
+        <a href="{{ url }}">{{ apiproductName }}</a>
       </h2>
-    {%- endif -%}
+
+    {{ content|without('apiProduct') }}
+
+    <hr class="my-4">
+    {{ label }}
+
+    {%- else -%}
     {{ title_suffix }}
 
     <div{{ content_attributes }}>
       {{ content }}
     </div>
+    {%- endif -%}
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
Closes #278 

Made Product name a heading and moved the rate plan name to the description.
This change is done for Apigee X BuyAPI listing page for apigee-devportal-kickstart-drupal and m10 module both.