### PR TITLE
Fix invalid handling of possible null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apigee Monetization Drupal module
 
-The Apigee Monetization module enables you to integrate Drupal 8 with Apigee Edge Monetization features. You must have
+The Apigee Monetization module enables you to integrate Drupal with Apigee Edge Monetization features. You must have
 an Apigee Edge organization with [monetization enabled](https://docs.apigee.com/api-platform/monetization/enabling-monetization-organization)
 to use this module.
 
@@ -55,4 +55,4 @@ Development is happening in our [GitHub repository](https://github.com/apigee/ap
 
 ## Support
 
-This project, which integrates Drupal 8 with Apigee Edge, is supported by Google.
+This project, which integrates Drupal with Apigee Edge, is supported by Google.

--- a/apigee_m10n.links.task.yml
+++ b/apigee_m10n.links.task.yml
@@ -34,7 +34,7 @@ apigee_m10n.purchased_plans:
 
 apigee_m10n.balance_and_product:
   route_name: entity.purchased_product.developer_product_collection
-  title: 'Purchased API products'
+  title: 'Manage Subscriptions'
   base_route: entity.user.canonical
 
 apigee_m10n.purchased_product:
@@ -51,11 +51,25 @@ apigee_m10n.billing:
   parent_id: apigee_m10n.balance_and_plans
   weight: -1
 
+apigee_m10n.balance_and_product.billing:
+  title: 'Prepaid balance'
+  route_name: apigee_monetization.xbilling
+  base_route: entity.user.canonical
+  parent_id: apigee_m10n.balance_and_product
+  weight: -1
+
 apigee_m10n.profile:
   title: 'Billing Details'
   route_name: apigee_monetization.profile
   base_route: entity.user.canonical
   parent_id: apigee_m10n.balance_and_plans
+  weight: 0
+
+apigee_m10n.balance_and_product.xprofile:
+  title: 'Billing Details'
+  route_name: apigee_monetization.xprofile
+  base_route: entity.user.canonical
+  parent_id: apigee_m10n.balance_and_product
   weight: 0
 
 apigee_m10n.reports:

--- a/apigee_m10n.module
+++ b/apigee_m10n.module
@@ -91,6 +91,8 @@ function apigee_m10n_theme($existing, $type, $theme, $path) {
         'fee_currency_code' => NULL,
         'fee_units' => NULL,
         'fee_nanos' => NULL,
+        'multipleConsumptionText' => NULL,
+        'singleConsumptionText' => NULL,
         'entity' => NULL,
       ],
       'template' => 'rate-plan-consumption-rates',
@@ -98,6 +100,9 @@ function apigee_m10n_theme($existing, $type, $theme, $path) {
     'rate_plan_revenue_rates' => [
       'variables' => [
         'detail' => NULL,
+        'revenueSharePercentage' => NULL,
+        'singleShareText' => NULL,
+        'multipleShareText' => NULL,
         'entity' => NULL,
       ],
       'template' => 'rate-plan-revenue-rates',

--- a/apigee_m10n.routing.yml
+++ b/apigee_m10n.routing.yml
@@ -130,6 +130,17 @@ apigee_monetization.billing:
   options:
     _apigee_monetization_route: TRUE
 
+apigee_monetization.xbilling:
+  path: /user/{user}/monetization/xbilling
+  defaults:
+    _controller: \Drupal\apigee_m10n\Controller\PrepaidBalanceXController::prepaidBalancePage
+    _title: Prepaid balance
+  requirements:
+    user: '^[1-9]+[0-9]*$'
+    _custom_access: \Drupal\apigee_m10n\Controller\PrepaidBalanceXController::access
+  options:
+    _apigee_monetization_route: TRUE
+
 apigee_monetization.my_plans:
   path: /plans
   defaults:
@@ -167,6 +178,17 @@ apigee_monetization.profile:
   requirements:
     user: '^[1-9]+[0-9]*$'
     _custom_access: \Drupal\apigee_m10n\Form\BillingDetailsForm::access
+  options:
+    _apigee_monetization_route: TRUE
+
+apigee_monetization.xprofile:
+  path: /user/{user}/monetization/xbilling-details
+  defaults:
+    _controller: \Drupal\apigee_m10n\Controller\BillingTypeController::myBillingType
+    _title: Billing Details
+  requirements:
+    user: '^[1-9]+[0-9]*$'
+    _custom_access: \Drupal\apigee_m10n\Controller\BillingTypeController::access
   options:
     _apigee_monetization_route: TRUE
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-bcmath": "*",
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
-        "drupal/apigee_edge": "^2.0.0",
+        "drupal/apigee_edge": "^1.25 || ^2.0.0",
         "drupal/core": "^8.9.19 || ^9.0.8",
         "drupal/requirement": "~1.0",
         "apigee/apigee-client-php": "^2.0.12"

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
         "ext-bcmath": "*",
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
-        "drupal/apigee_edge": "^1.22",
+        "drupal/apigee_edge": "^2.0.0",
         "drupal/core": "^8 || ^9",
         "drupal/requirement": "~1.0",
-        "apigee/apigee-client-php": "^2.0.8"
+        "apigee/apigee-client-php": "^2.0.12"
     },
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
         "drupal/apigee_edge": "^2.0.0",
-        "drupal/core": "^8 || ^9",
+        "drupal/core": "^8.9.19 || ^9.0.8",
         "drupal/requirement": "~1.0",
         "apigee/apigee-client-php": "^2.0.12"
     },

--- a/config/install/core.entity_view_display.xrate_plan.xrate_plan.default.yml
+++ b/config/install/core.entity_view_display.xrate_plan.xrate_plan.default.yml
@@ -42,15 +42,6 @@ content:
       strip_trailing_zeroes: false
       currency_display: symbol
     third_party_settings: {  }
-  consumptionFee:
-    type: apigee_price
-    weight: 5
-    region: content
-    label: inline
-    settings:
-      strip_trailing_zeroes: false
-      currency_display: symbol
-    third_party_settings: {  }
   feeFrequency:
     type: string
     weight: 4
@@ -60,7 +51,7 @@ content:
     third_party_settings: {  }
   consumptionPricingType:
     type: string
-    weight: 7
+    weight: 5
     region: content
     label: inline
     settings: {  }
@@ -94,11 +85,33 @@ content:
     settings:
       label: 'Purchase Product'
     third_party_settings: {  }
+  consumptionPricingRates:
+    type: apigee_rate_plan_consumption_rates
+    weight: 6
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  revenueShareRates:
+    type: apigee_rate_plan_revenue_rates
+    weight: 8
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  revenueShareType:
+    type: string
+    weight: 7
+    region: content
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
   description: true
   id: true
   name: true
-  revenueShareType: true
   currencyCode: true
   billingPeriod: true
   fixedFeeFrequency: true
+  consumptionFee: true

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.libraries.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.libraries.yml
@@ -7,3 +7,7 @@ settings:
   css:
     theme:
       css/apigee_m10n_add_credit.settings.css: {}
+
+add_credit_price:
+  js:
+    js/apigee_m10n_add_credit.add_credit.js: {}

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.links.menu.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.links.menu.yml
@@ -4,3 +4,11 @@ apigee_m10n_add_credit.settings.add_credit:
   description: 'Configure adding credit using Drupal Commerce module.'
   parent: apigee_m10n.settings.prepaid_balance
   weight: 99
+
+apigee_m10n_add_credit.settings.generalsettings:
+  class: Drupal\apigee_m10n_add_credit\Plugin\Menu\GeneralSettingsPluginClass
+  title: 'General Settings'
+  route_name: apigee_m10n_add_credit.settings.generalsettings
+  description: 'Configure General Settings.'
+  parent: system.admin_apigee_m10n
+  weight: 101

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.links.task.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.links.task.yml
@@ -2,3 +2,14 @@ apigee_m10n_add_credit.settings.add_credit:
   route_name: apigee_m10n_add_credit.settings.add_credit
   title: 'Add credit'
   base_route: apigee_m10n.settings.prepaid_balance
+
+apigee_m10n_add_credit.settings.generalsettings:
+  title: 'General Settings'
+  route_name: apigee_m10n_add_credit.settings.generalsettings
+  base_route: apigee_m10n_add_credit.settings.generalsettings
+  weight: -10
+
+apigee_m10n_add_credit.userbillingtype:
+  title: 'Billing Type'
+  route_name: apigee_m10n_add_credit.userbillingtype
+  base_route: entity.user.canonical

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.module
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.module
@@ -19,12 +19,16 @@
  */
 
 use Drupal\apigee_m10n\Entity\PurchasedPlanInterface;
+use Drupal\apigee_m10n\Entity\PurchasedProductInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\apigee_edge\Entity\Developer;
+use Drupal\user\UserInterface;
+use Drupal\apigee_m10n_add_credit\Form\GeneralSettingsConfigForm;
 
 /**
  * Implements hook_mail().
@@ -118,8 +122,30 @@ function apigee_m10n_add_credit_apigee_m10n_insufficient_balance_error_message_a
 }
 
 /**
+ * Implements hook_apigee_m10n_insufficient_balance_error_purchased_product_message_alter().
+ */
+function apigee_m10n_add_credit_apigee_m10n_insufficient_balance_error_purchased_product_message_alter(TranslatableMarkup &$message, PurchasedProductInterface $purchased_product) {
+  return \Drupal::service('apigee_m10n.add_credit')->purchasedProductInsufficientBalanceErrorMessageAlter($message, $purchased_product);
+}
+
+/**
  * Implements hook_help().
  */
 function apigee_m10n_add_credit_help($route_name, RouteMatchInterface $route_match) {
   return \Drupal::service('apigee_m10n.add_credit')->help($route_name, $route_match);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function apigee_m10n_add_credit_user_presave(UserInterface $account) {
+  // Check if org is ApigeeX.
+  if (TRUE === \Drupal::service('apigee_m10n.monetization')->isOrganizationApigeeXorHybrid()) {
+    // Check if new user and add the billing type.
+    if ($account->isNew()) {
+      $default_billingtype = \Drupal::config(GeneralSettingsConfigForm::CONFIG_NAME)->get('billing.billingtype');
+      $default_billingtype = $default_billingtype ? $default_billingtype : 'POSTPAID';
+      \Drupal::service('apigee_m10n.monetization')->updateBillingType($account->getEmail(), strtoupper($default_billingtype));
+    }
+  }
 }

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.permissions.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.permissions.yml
@@ -3,3 +3,6 @@ permission_callbacks:
 
 view add credit log:
   title: 'View Add Credit Log'
+
+update any billing type:
+  title: 'Update any billing type'

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.routing.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.routing.yml
@@ -7,3 +7,38 @@ apigee_m10n_add_credit.settings.add_credit:
     _permission: 'access administration pages'
   options:
     _apigee_monetization_route: TRUE
+
+apigee_m10n_add_credit.settings.generalsettings:
+  path: /admin/config/apigee-monetization/general/settings
+  defaults:
+    _form: \Drupal\apigee_m10n_add_credit\Form\GeneralSettingsConfigForm
+    _title: General Settings
+  requirements:
+    _permission: administer apigee monetization
+    _custom_access: \Drupal\apigee_m10n_add_credit\Form\GeneralSettingsConfigForm::access
+  options:
+    _apigee_monetization_route: TRUE
+
+apigee_m10n_add_credit.userbillingtype:
+  path: /user/{user}/monetization/user-billingtype
+  defaults:
+    _form: \Drupal\apigee_m10n_add_credit\Form\BillingTypeForm
+    _title: Billing Type
+  requirements:
+    user: '^[1-9]+[0-9]*$'
+    _custom_access: \Drupal\apigee_m10n_add_credit\Form\BillingTypeForm::access
+  options:
+    _apigee_monetization_route: TRUE
+    no_cache: 'TRUE'
+
+apigee_m10n_add_credit.userbillingtype.confirm:
+  path: /user/{user}/monetization/{billingtype}/confirm
+  defaults:
+    _form: \Drupal\apigee_m10n_add_credit\Form\ConfirmUpdateForm
+    _title: 'Confirm Update'
+  requirements:
+    user: '^[1-9]+[0-9]*$'
+    _custom_access: \Drupal\apigee_m10n_add_credit\Form\ConfirmUpdateForm::access
+  options:
+    _apigee_monetization_route: TRUE
+    no_cache: 'TRUE'

--- a/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.services.yml
+++ b/modules/apigee_m10n_add_credit/apigee_m10n_add_credit.services.yml
@@ -20,3 +20,10 @@ services:
   plugin.manager.apigee_add_credit_entity_type:
     class: Drupal\apigee_m10n_add_credit\Plugin\AddCreditEntityTypeManager
     parent: default_plugin_manager
+
+  apigee_m10n_add_credit.commerce_currency_subscriber:
+    class: Drupal\apigee_m10n_add_credit\EventSubscriber\CommerceCurrencyConfigSubscriber
+    arguments: ['@config.factory', '@entity_type.manager', '@apigee_m10n.monetization']
+    tags:
+      - { name: event_subscriber }
+

--- a/modules/apigee_m10n_add_credit/config/install/apigee_m10n_add_credit.general_settings.config.yml
+++ b/modules/apigee_m10n_add_credit/config/install/apigee_m10n_add_credit.general_settings.config.yml
@@ -1,0 +1,3 @@
+billing:
+  billingtype: 'postpaid'
+wait_time: 300

--- a/modules/apigee_m10n_add_credit/config/schema/apigee_m10n_add_credit.schema.yml
+++ b/modules/apigee_m10n_add_credit/config/schema/apigee_m10n_add_credit.schema.yml
@@ -69,3 +69,17 @@ field.value.add_credit_target_entity:
     target_type:
       type: string
       label: 'Entity type'
+
+apigee_m10n_add_credit.general_settings.config:
+  type: config_object
+  label: 'General settings'
+  mapping:
+    billing:
+      type: mapping
+      mapping:
+        billingtype:
+          type: string
+          label: 'Billing Type'
+    wait_time:
+      type: integer
+      label: 'How much time to wait till the next topup balance.'

--- a/modules/apigee_m10n_add_credit/js/apigee_m10n_add_credit.add_credit.js
+++ b/modules/apigee_m10n_add_credit/js/apigee_m10n_add_credit.add_credit.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+/**
+ * @file
+ * Allow only 2 decimal points for price field.
+ */
+(function ($, Drupal) {
+
+  'use strict';
+
+  Drupal.behaviors.apigee_m10n_add_credit_price = {
+    attach: function attach(context) {
+      var self = this;
+      $(".two_decimal_price div input").keyup(function(){
+      var number = ($(this).val().split('.'));
+        if (number[1].length > 2)
+        {
+          var price = parseFloat($(this).val());
+          $(this).val(price.toFixed(2));
+        }
+      });
+    },
+  };
+})(jQuery, Drupal);

--- a/modules/apigee_m10n_add_credit/src/AddCreditServiceInterface.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditServiceInterface.php
@@ -20,6 +20,7 @@
 namespace Drupal\apigee_m10n_add_credit;
 
 use Drupal\apigee_m10n\Entity\PurchasedPlanInterface;
+use Drupal\apigee_m10n\Entity\PurchasedProductInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -204,5 +205,18 @@ interface AddCreditServiceInterface {
    *   The altered message.
    */
   public function insufficientBalanceErrorMessageAlter(TranslatableMarkup &$message, PurchasedPlanInterface $purchased_plan);
+
+  /**
+   * Handles `hook_apigee_m10n_insufficient_balance_error_purchased_product_message_alter`.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $message
+   *   The original message.
+   * @param \Drupal\apigee_m10n\Entity\PurchasedProductInterface $purchased_product
+   *   The failed purchased_product.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The altered message.
+   */
+  public function purchasedProductInsufficientBalanceErrorMessageAlter(TranslatableMarkup &$message, PurchasedProductInterface $purchased_product);
 
 }

--- a/modules/apigee_m10n_add_credit/src/EventSubscriber/CommerceCurrencyConfigSubscriber.php
+++ b/modules/apigee_m10n_add_credit/src/EventSubscriber/CommerceCurrencyConfigSubscriber.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\apigee_m10n_add_credit\CommerceCurrencyConfigSubscriber.
+ */
+
+namespace Drupal\apigee_m10n_add_credit\EventSubscriber;
+
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\apigee_m10n_add_credit\AddCreditConfig;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\commerce_price\Price;
+use Drupal\apigee_m10n\MonetizationInterface;
+
+/**
+ * Class CommerceCurrencyConfigSubscriber.
+ *
+ * @package Drupal\apigee_m10n_add_credit\EventSubscriber
+ */
+class CommerceCurrencyConfigSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The monetization service.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * CommerceCurrencyConfigSubscriber constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   The monetization service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, MonetizationInterface $monetization) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->monetization = $monetization;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   *   The event to listen, and the methods to be executed.
+   */
+  public static function getSubscribedEvents() {
+    $events[ConfigEvents::SAVE] = ['onCurrencySave', -100];
+    $events[ConfigEvents::DELETE] = ['onCurrencyDelete', -100];
+
+    return $events;
+  }
+
+  /**
+   * React to a config object being saved.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   Config save event.
+   */
+  public function onCurrencySave(ConfigCrudEvent $event) {
+    $config = $event->getConfig();
+
+    // Excecuted when new currency is saved.
+    // For new currencies orginal data is empty array.
+    if (!$config->getOriginal() && strpos($config->getName(), 'commerce_price.commerce_currency') !== FALSE) {
+      if ($this->monetization->isOrganizationApigeeXorHybrid()) {
+        $raw_data = $config->getRawData();
+        $currencyCode = $raw_data['currencyCode'];
+        // Get the commerce store storeage.
+        $store_storage = $this->entityTypeManager->getStorage('commerce_store');
+        // Fetch the default store enabled to store the product.
+        $default_store = $store_storage->loadDefault();
+
+        // Get the product_variation type.
+        $variation_type_storage = $this->entityTypeManager
+          ->getStorage('commerce_product_variation_type');
+        $variation_type = $variation_type_storage->load('add_credit');
+
+        if ($variation_type) {
+          $variation = $this->entityTypeManager
+            ->getStorage('commerce_product_variation')
+            ->create([
+              'type' => 'add_credit',
+              'sku' => "ADD-CREDIT-{$currencyCode}",
+              'title' => $currencyCode,
+              'status' => 1,
+              'price' => new Price(1, $currencyCode),
+            ]);
+          $variation->set('apigee_price_range', [
+            'minimum' => 1,
+            'maximum' => 999,
+            'default' => 1,
+            'currency_code' => $currencyCode,
+          ]);
+          $variation->save();
+        }
+        // Get the product type.
+        $product_type_storage = $this->entityTypeManager
+          ->getStorage('commerce_product_type');
+        $product_type = $product_type_storage->load('add_credit');
+
+        if ($product_type) {
+          // Create an add credit product for this currency.
+          $product = $this->entityTypeManager->getStorage('commerce_product')
+            ->create([
+              'title' => $currencyCode,
+              'type' => 'add_credit',
+              'stores' => [$default_store->id()],
+              'variations' => [$variation],
+              AddCreditConfig::ADD_CREDIT_ENABLED_FIELD_NAME => 1,
+            ]);
+          $product->save();
+
+          // Save config.
+          $this->configFactory
+            ->getEditable(AddCreditConfig::CONFIG_NAME)
+            ->set('products.' . strtolower($currencyCode), [
+              'product_id' => $product->id(),
+            ])
+            ->save();
+        }
+      }
+    }
+  }
+
+  /**
+   * React to a config object being delete.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   Config delete event.
+   */
+  public function onCurrencyDelete(ConfigCrudEvent $event) {
+    $config = $event->getConfig();
+
+    // Excecuted when currency is deleted.
+    if (strpos($config->getName(), 'commerce_price.commerce_currency') !== FALSE) {
+      if ($this->monetization->isOrganizationApigeeXorHybrid()) {
+        $original_data = $config->getOriginal();
+        $currencyCode = $original_data['currencyCode'];
+        $addCreditProducts = $this->entityTypeManager->getStorage('commerce_product')->loadByProperties([
+          'apigee_add_credit_enabled' => '1'
+          ]
+        );
+        foreach ($addCreditProducts as $product) {
+          if ($product_variation = $product->getDefaultVariation()) {
+            if ($product_variation->getPrice()->getCurrencyCode() === $currencyCode) {
+              $product->delete();
+              // Save config.
+              $this->configFactory
+                ->getEditable(AddCreditConfig::CONFIG_NAME)
+                ->clear('products.' . strtolower($currencyCode))
+                ->save();
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_add_credit\Form;
+
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperBillingTypeController;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\user\UserInterface;
+use Drupal\apigee_edge\Entity\Developer;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\apigee_m10n_add_credit\Form\GeneralSettingsConfigForm;
+
+/**
+ * Provides a form to edit developer profile information.
+ */
+class BillingTypeForm extends FormBase {
+
+  /**
+   * Developer.
+   *
+   * @var \Drupal\apigee_edge\Entity\Developer
+   */
+  protected $developer;
+
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The Monetization base.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * Constructs a CompanyProfileForm object.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   The logger.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   The current route match.
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   Monetization base.
+   */
+  public function __construct(LoggerChannelFactory $loggerFactory, MessengerInterface $messenger, RouteMatchInterface $routeMatch, MonetizationInterface $monetization) {
+    $this->loggerFactory = $loggerFactory->get('apigee_m10n');
+    $this->messenger = $messenger;
+    $this->routeMatch = $routeMatch;
+    $this->monetization = $monetization;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $user = $container->get('current_route_match')->getParameter('user');
+
+    return new static(
+      $container->get('logger.factory'),
+      $container->get('messenger'),
+      $container->get('current_route_match'),
+      $container->get('apigee_m10n.monetization')
+    );
+  }
+
+  /**
+   * Checks current users access to Billing Profile page.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Grants access to the route if passed permissions are present.
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account) {
+
+    if (!$this->monetization->isOrganizationApigeeXorHybrid()) {
+      return AccessResult::forbidden('Only accessible for ApigeeX organization');
+    }
+
+    $user = $route_match->getParameter('user');
+    try {
+      $developer_billingtype = $this->monetization->getBillingtype($user);
+    }
+    catch (\Exception $e) {
+      return AccessResult::forbidden('Developer does not exist.');
+    }
+
+    return AccessResult::allowedIf(
+      $account->hasPermission('update any billing type')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'user_billing_type_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, UserInterface $user = NULL) {
+    $billingType = ['postpaid' => 'Postpaid' , 'prepaid' => 'Prepaid'];
+    $developer_billingtype = $this->monetization->getBillingtype($user);
+    $form['billingtype'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Billing Type'),
+      '#options' => $billingType,
+      '#default_value' => $developer_billingtype ? strtolower($developer_billingtype) : 'postpaid',
+      '#description' => $this->t('Select the billing type for the user.'),
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save changes'),
+      '#button_type' => 'primary',
+      '#states' => [
+        'disabled' => [
+          ':input[name="billingtype"]' => ['value' => strtolower($developer_billingtype)],
+        ]
+      ]
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state, UserInterface $user = NULL) {
+    $user = $this->routeMatch->getParameter('user');
+    $billingtype_selected = $form_state->getValue('billingtype');
+    $form_state->setRedirect('apigee_m10n_add_credit.userbillingtype.confirm', ['user' => $user->id(), 'billingtype' => $billingtype_selected]);
+  }
+
+}

--- a/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_add_credit\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperBillingTypeController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\user\Entity\User;
+use Drupal\apigee_edge\Entity\Developer;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\apigee_m10n\MonetizationInterface;
+
+/**
+ * Defines a confirmation form to confirm updating of developer billing type.
+ */
+class ConfirmUpdateForm extends ConfirmFormBase {
+
+  /**
+   * The user from route.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The Monetization base.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * Constructs a Confirmation object.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   The current route match.
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   Monetization base.
+   */
+  public function __construct(MessengerInterface $messenger, RouteMatchInterface $routeMatch, MonetizationInterface $monetization) {
+    $this->messenger = $messenger;
+    $this->routeMatch = $routeMatch;
+    $this->monetization = $monetization;
+    $this->userId = $routeMatch->getParameter('user');
+    $this->user = User::load($this->userId);
+    $this->billingtype_selected = $routeMatch->getParameter('billingtype');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger'),
+      $container->get('current_route_match'),
+      $container->get('apigee_m10n.monetization')
+    );
+  }
+
+  /**
+   * Checks current users access to Billing Profile page.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Grants access to the route if passed permissions are present.
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account) {
+    return AccessResult::allowedIf(
+      $account->hasPermission('update any billing type')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    $form = parent::buildForm($form, $form_state);
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    try {
+      $developer_billing_type = $this->monetization->updateBillingtype($this->user->getEmail(), strtoupper($this->billingtype_selected));
+      $this->messenger->addStatus($this->t('Billing type of the user is saved.'));
+      $form_state->setRedirect('entity.user.edit_form', ['user' => $this->user->id()]);
+      drupal_flush_all_caches();
+    }
+    catch (\Exception $e) {
+      $this->messenger->addError($e->getMessage());
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "confirm_change_billing_type_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('apigee_m10n_add_credit.userbillingtype', ['user' => $this->userId]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+
+    return $this->t('Are you sure you want to change the billing type for user- %email?', ['%email' => $this->user->getEmail()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    // Fetch the billing type of the developer.
+    $original = $this->monetization->getBillingtype($this->user);
+    if ('prepaid' == strtolower($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('If the developer billing type is changed from "prepaid" to "postpaid," any existing prepaid balance will be treated as a credit transaction when calculating amounts due.');
+    }
+    elseif (('postpaid' == strtolower($original) || !($original))&& 'prepaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('If the developer billing type is changed from "postpaid" to "prepaid," developers should perform a balance top-up to ensure that API calls are not blocked due to an insufficient balance.');
+    }
+    elseif (!($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('The billing type will to switched to Postpaid.');
+    }
+  }
+
+}

--- a/modules/apigee_m10n_add_credit/src/Form/GeneralSettingsConfigForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/GeneralSettingsConfigForm.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Drupal\apigee_m10n_add_credit\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * Config form for general setting.
+ */
+class GeneralSettingsConfigForm extends ConfigFormBase {
+
+  /**
+   * The config named used by this form.
+   */
+  const CONFIG_NAME = 'apigee_m10n_add_credit.general_settings.config';
+
+  /**
+   * Apigee Monetization base service.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, MonetizationInterface $monetization) {
+    parent::__construct($config_factory);
+    $this->monetization = $monetization;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('apigee_m10n.monetization')
+    );
+  }
+
+  /**
+   * Checks if ApigeeX org.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Grants access to the route if the org id ApigeeX.
+   */
+  public function access() {
+
+    if (!$this->monetization->isOrganizationApigeeXorHybrid()) {
+      return AccessResult::forbidden('Only accessible for ApigeeX organization');
+    }
+    else {
+      return AccessResult::allowed();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [static::CONFIG_NAME];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'general_settings_config_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(static::CONFIG_NAME);
+
+    $billingType = ['postpaid' => 'Postpaid' , 'prepaid' => 'Prepaid'];
+
+    $form['billing'] = [
+      '#title' => $this->t('General Settings'),
+      '#type' => 'details',
+      '#open' => TRUE,
+    ];
+
+    $form['billing']['billingtype'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Billing Type'),
+      '#default_value' => $config->get('billing.billingtype'),
+      '#options' => $billingType,
+      '#description' => $this->t('Select default billing type for users signing up for the portal.'),
+    ];
+
+    $form['time'] = [
+      '#title' => $this->t('Maximum wait Settings'),
+      '#type' => 'details',
+      '#open' => TRUE,
+    ];
+
+    $form['time']['wait_time'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Topup balance wait.'),
+      '#description' => $this->t('Portal blocks the frequent top-ups by disabling the add credit option for the above mentioned period.'),
+      '#default_value' => $config->get('wait_time'),
+      '#required' => TRUE,
+      '#min' => 0,
+      '#max' => 3600,
+      '#field_suffix' => t('seconds'),
+    ];
+
+    // Add a note about changing the wait time.
+    $form['time']['note'] = [
+      '#markup' => $this->t('<div class="apigee-add-credit-notification-note"><div class="label">@note</div><div>@description</div></div>', [
+        '@note' => 'Note:',
+        '@description' => "Apigee backend API for credit balance doesn't allow frequent top-ups,
+                          and hence in line with the same,
+                          the portal also disables the add credit option for a fixed period.
+                          If you want to change the above value, please make sure the changes
+                          fits well with the backend API guarantees.",
+      ]),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config(static::CONFIG_NAME)
+      ->set('billing.billingtype', $form_state->getValue('billingtype'))
+      ->set('wait_time', $form_state->getValue('wait_time'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJobX.php
+++ b/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJobX.php
@@ -1,0 +1,384 @@
+<?php
+
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_add_credit\Job;
+
+use Apigee\Edge\Api\ApigeeX\Controller\PrepaidBalanceControllerInterface;
+use Drupal\apigee_edge\Entity\DeveloperInterface;
+use Drupal\apigee_edge\Job\EdgeJob;
+use Drupal\apigee_m10n\Controller\PrepaidBalanceXController;
+use Drupal\apigee_m10n_add_credit\AddCreditConfig;
+use Drupal\commerce_order\Adjustment;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_price\Price;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\user\UserInterface;
+
+/**
+ * An apigee job that will apply a balance adjustment.
+ *
+ * The job is responsible for updating the account balance for a developer or
+ * company. It is usually initiated after an add credit product is purchased.
+ *
+ * Execute should not return anything if the job was successful. Throwing an
+ * error will let the job runner know that the request was unsuccessful and will
+ * trigger a retry.
+ *
+ * @todo: Handle refunds when the monetization API supports it.
+ */
+class BalanceAdjustmentJobX extends EdgeJob {
+
+  use StringTranslationTrait;
+
+  /**
+   * The developer account to whom a balance adjustment is to be made.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $developer;
+
+  /**
+   * The drupal commerce adjustment.
+   *
+   * Co-opt the commerce adjustment since this module requires it anyway. For
+   * the context of this job the adjustment is what is to be made to the account
+   * balance. An increase to the account balance would be a positive adjustment
+   * and a decrease would be a negative adjustment.
+   *
+   * @var \Drupal\commerce_order\Adjustment
+   */
+  protected $adjustment;
+
+  /**
+   * The drupal commerce order.
+   *
+   * @var \Drupal\commerce_order\Entity\OrderInterface
+   */
+  protected $order;
+
+  /**
+   * The `apigee_m10n_add_credit` module config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $module_config;
+
+  /**
+   * Creates an Apigee balance adjustment (add credit) job.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $developer
+   *   The company  or user the adjustment should  be applied to.
+   * @param \Drupal\commerce_order\Adjustment $adjustment
+   *   The drupal commerce adjustment.
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The drupal commerce order.
+   */
+  public function __construct(EntityInterface $developer, Adjustment $adjustment, OrderInterface $order = NULL) {
+    parent::__construct();
+
+    $this->developer = $developer->getOwner();
+
+    $this->adjustment = $adjustment;
+
+    $this->order = $order;
+
+    $this->module_config = \Drupal::config(AddCreditConfig::CONFIG_NAME);
+
+    $this->setTag('prepaid_balance_update_wait');
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Throwable
+   */
+  protected function executeRequest() {
+    $adjustment = $this->adjustment;
+
+    $currency_code = $adjustment->getAmount()->getCurrencyCode();
+
+    list($units, $decimal) = explode('.', $adjustment->getAmount()->getNumber());
+    $nanos = ('0.' . $decimal) * pow(10, 9);
+
+    // Grab the current balances.
+    if ($controller = $this->getBalanceController()) {
+      // Get existing balance with the same currency code.
+      $balance = $this->getPrepaidBalance($controller, $currency_code);
+
+      // Fetch the nanos and the units.
+      $existing_top_ups = new Price(!empty($balance) ? (string) ($balance->getBalance()->getUnits() + $balance->getBalance()->getNanos()) : '0', $currency_code);
+      // Calculate the expected new balance.
+      $expected_balance = $existing_top_ups->add($adjustment->getAmount());
+
+      $transaction_time = new \DateTimeImmutable();
+
+      try {
+        // Top up by the adjustment amount.
+        $transaction_id = !empty($this->order->getOrderNumber()) ? $this->order->getOrderNumber() : $this->order->id();
+        $controller->topUpBalance($units, $nanos, $currency_code, $transaction_id);
+
+        // The data returned from `topUpBalance` doesn't get us the new top up
+        // total so we have to grab that from the balance controller again.
+        $balance_after = $this->getPrepaidBalance($controller, $currency_code);
+        $cal_new_balance = $balance_after->getBalance()->getUnits() + $balance_after->getBalance()->getNanos();
+        $new_balance = new Price((string) ($cal_new_balance), $currency_code);
+      }
+      catch (\Throwable $t) {
+        // Nothing gets logged/reported if we let errors end the job here.
+        $this->getLogger()->error((string) $t);
+        $thrown = $t;
+      }
+
+      // Check the balance again to make sure the amount is correct.
+      if (!empty($new_balance)
+        && !empty($new_balance->getNumber())
+        && ($expected_balance->getNumber() === $new_balance->getNumber())
+      ) {
+        // Set the log action.
+        $log_action = 'info';
+      }
+      else {
+        // Something is fishy here, we should log as an error.
+        $log_action = 'error';
+      }
+
+      // Get the appropriate report text from the lookup table.
+      $report_text = $this->getMessage("report_text_{$log_action}_header") . $this->getMessage('report_text');
+
+      // Compile message context.
+      $context = [
+        'email'             => !empty($this->developer) ? $this->developer->getEmail() : '',
+        'existing'          => $this->formatPrice($existing_top_ups),
+        'adjustment'        => $this->formatPrice($adjustment->getAmount()),
+        'new_balance'       => isset($new_balance) ? $this->formatPrice($new_balance) : 'Error retrieving the new balance.',
+        'expected_balance'  => $this->formatPrice($expected_balance),
+        'month'             => date('F'),
+      ];
+
+      // Report the transaction.
+      $this->getLogger()->{$log_action}($report_text, $context);
+
+      /** @var \Drupal\Core\Logger\LogMessageParser $message_parser */
+      $message_parser = \Drupal::service('logger.log_message_parser');
+      // Strip br html tags.
+      $report_text = str_replace('<br />', '', $report_text);
+      // The message parser strips out empty values so we may need to re-add
+      // some empty values for formatting.
+      $all_placeholders = [
+        '@email' => '',
+        '@existing' => '',
+        '@adjustment' => '',
+        '@new_balance' => '',
+        '@expected_balance' => '',
+        '@month' => '',
+      ];
+      // Format the message using the log message parser.
+      $message_context = $message_parser->parseMessagePlaceholders($report_text, $context);
+      // Re-add empty values to message context.
+      $message_context = $message_context + $all_placeholders;
+      // Add the report text to the message context.
+      $message_context['report_text'] = $report_text;
+
+      // If there were any errors or exceptions, they still need to be thrown.
+      if (isset($thrown)) {
+        $message_context['@error'] = (string) $thrown;
+        // Sent the notification.
+        $this->sendNotification('balance_adjustment_error_report', $message_context);
+
+        throw $thrown;
+      }
+      elseif ($this->module_config->get('notify_on') == AddCreditConfig::NOTIFY_ALWAYS) {
+        $this->sendNotification('balance_adjustment_report', $message_context);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldRetry(\Exception $exception): bool {
+    // We aren't retrying requests ATM. If we can confirm that the payment
+    // wasn't applied, we could return true here and the top-up would be
+    // retried.
+    // @todo Return true once we can determine the payment wasn't applied.
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString(): string {
+    // Use "Add" for an increase adjustment or "Subtract" for a decrease.
+    $adj_verb = $this->adjustment->isPositive() ? 'Add' : 'Subtract';
+    $abs_price = new Price(abs($this->adjustment->getAmount()->getNumber()), $this->adjustment->getAmount()->getCurrencyCode());
+
+    return t(":adj_verb :amount to :account", [
+      ':adj_verb' => $adj_verb,
+      ':amount' => $this->formatPrice($abs_price),
+      ':account' => $this->developer->getEmail(),
+    ]);
+  }
+
+  /**
+   * Get's the prepaid balance information from the given controller.
+   *
+   * @param \Apigee\Edge\Api\ApigeeX\Controller\PrepaidBalanceControllerInterface $controller
+   *   The developer controller.
+   * @param string $currency_code
+   *   The currency code to retrieve the balance for.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface|null
+   *   The balance for this adjustment currency.
+   *
+   * @throws \Exception
+   */
+  protected function getPrepaidBalance(PrepaidBalanceControllerInterface $controller, $currency_code) {
+    /** @var \Apigee\Edge\Api\Monetization\Entity\PrepaidBalanceInterface[] $balances */
+    $balances = $controller->getPrepaidBalance();
+
+    if (!empty($balances)) {
+      $balances = array_combine(array_map(function ($balance) {
+        return $balance->getBalance()->getCurrencyCode();
+      }, $balances), $balances);
+    }
+    return !empty($balances[$currency_code]) ? $balances[$currency_code] : NULL;
+  }
+
+  /**
+   * Get's the logger for this job.
+   *
+   * @return \Psr\Log\LoggerInterface
+   *   The Psr7 logger.
+   */
+  protected function getLogger() {
+    return \Drupal::service('logger.channel.apigee_m10n_add_credit');
+  }
+
+  /**
+   * Gets the developer balance controller for the developer user.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Controller\PrepaidBalanceControllerInterface|false
+   *   The developer balance controller
+   */
+  protected function getBalanceController() {
+    // Return the appropriate controller for the operational entity type.
+    return \Drupal::service('apigee_m10n.sdk_controller_factory')
+      ->developerBalancexController($this->developer);
+  }
+
+  /**
+   * Get's the drupal commerce currency formatter.
+   *
+   * @return \CommerceGuys\Intl\Formatter\CurrencyFormatterInterface
+   *   The currency formatter.
+   */
+  protected function currencyFormatter() {
+    return \Drupal::service('commerce_price.currency_formatter');
+  }
+
+  /**
+   * Formats a commerce price using the currency formatter service.
+   *
+   * @param \Drupal\commerce_price\Price $price
+   *   The commerce price to be formatted.
+   *
+   * @return string
+   *   The formatted price, i.e. $100 USD.
+   */
+  protected function formatPrice(Price $price) {
+    return $this->currencyFormatter()->format(
+      $price->getNumber(),
+      strtoupper($price->getCurrencyCode()),
+      [
+        'currency_display'        => 'symbol',
+        'minimum_fraction_digits' => 2,
+      ]
+    );
+  }
+
+  /**
+   * Helper to determine if this is a developer adjustment.
+   *
+   * @return bool
+   *   True if this is a developer adjustment.
+   */
+  protected function isDeveloperAdjustment(): bool {
+    return !empty($this->developer);
+  }
+
+  /**
+   * Get a message.
+   *
+   * A lookup for messages that depends on the type of adjustment we are dealing
+   * with here.
+   *
+   * @param string $message_id
+   *   An identifier for the message.
+   *
+   * @return string
+   *   The message.
+   */
+  protected function getMessage($message_id) {
+    $type = 'developer';
+
+    $report_text = 'Existing credit added ({month}):  `{existing}`.<br />' . PHP_EOL;
+    $report_text .= 'Amount Applied:                   `{adjustment}`.<br />' . PHP_EOL;
+    $report_text .= 'New Balance:                      `{new_balance}`.<br />' . PHP_EOL;
+    $report_text .= 'Expected New Balance:             `{expected_balance}`.<br />' . PHP_EOL;
+
+    $messages = [
+      'developer' => [
+        'balance_error_message' => 'Apigee User ({email}) has no balance for ({currency}).',
+        'report_text_error_header' => 'Calculation discrepancy applying adjustment to developer `{email}`. <br />' . PHP_EOL . PHP_EOL,
+        'report_text_info_header'  => 'Adjustment applied to developer:  `{email}`. <br />' . PHP_EOL . PHP_EOL,
+        'report_text'              => $report_text,
+      ],
+    ];
+
+    return $messages[$type][$message_id];
+  }
+
+  /**
+   * Send a notification using drupal mail API.
+   *
+   * @param string $notification_type
+   *   The notificaiton type.
+   * @param array|null $message_context
+   *   The message context.
+   */
+  protected function sendNotification($notification_type, $message_context) {
+    // Email the error to an administrator.
+    $recipient = !empty($this->module_config->get('notification_recipient'))
+      ? $this->module_config->get('notification_recipient')
+      : \Drupal::config('system.site')->get('mail');
+    $recipient = !empty($recipient) ? $recipient : ini_get('sendmail_from');
+    \Drupal::service('plugin.manager.mail')->mail(
+      'apigee_m10n_add_credit',
+      $notification_type,
+      $recipient,
+      Language::LANGCODE_DEFAULT,
+      $message_context
+    );
+  }
+
+}

--- a/modules/apigee_m10n_add_credit/src/Plugin/Menu/GeneralSettingsPluginClass.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Menu/GeneralSettingsPluginClass.php
@@ -1,5 +1,7 @@
+<?php
+
 /*
- * Copyright 2018 Google Inc.
+ * Copyright 2021 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License version 2 as published by the
@@ -14,28 +16,27 @@
  * with this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-.apigee-m10n-prepaid-balance-wrapper {
-  position: relative;
-}
 
-.apigee-m10n-prepaid-balance-wrapper > table > caption {
-  padding-top: 20px;
-}
+namespace Drupal\apigee_m10n_add_credit\Plugin\Menu;
 
-.apigee-m10n-prepaid-balance-wrapper .prepaid-balance-refresh-form {
-  position: absolute;
-  top: 0;
-  right: 0;
-}
+use Drupal\Core\Menu\MenuLinkDefault;
 
-.apigee-m10n-prepaid-balance-wrapper .prepaid-balance-refresh-form .form-submit {
-  margin-right: 0;
-}
+/**
+ * Defines the class for entity admin form switching.
+ */
+class GeneralSettingsPluginClass extends MenuLinkDefault {
 
-.disable-add-credit{
-  pointer-events: none;
-  cursor: not-allowed;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  box-shadow: none;
+  /**
+   * {@inheritdoc}
+   */
+  public function isEnabled() {
+    $monetization = \Drupal::service('apigee_m10n.monetization');
+    if ($monetization->isOrganizationApigeeXorHybrid()) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
 }

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProductType.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProductType.php
@@ -21,6 +21,7 @@ namespace Drupal\apigee_m10n_add_credit\Plugin\Requirement\Requirement;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\requirement\Plugin\RequirementBase;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
 
 /**
  * Check that the "Add credit" product type has been configured.
@@ -58,6 +59,42 @@ class AddCreditProductType extends RequirementBase {
     /* @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface $display_repository */
     $display_repository = \Drupal::service('entity_display.repository');
 
+    $order_type_id = '';
+    if (\Drupal::service('apigee_m10n.monetization')->isOrganizationApigeeXorHybrid()) {
+      // Get or create the number pattern.
+      $number_pattern_storage = $this->getEntityTypeManager()
+        ->getStorage('commerce_number_pattern');
+      $number_pattern = $number_pattern_storage->load('add_credit');
+
+      if (!$number_pattern) {
+        $number_pattern = $number_pattern_storage->create([
+          'status' => 1,
+          'id' => 'add_credit',
+          'label' => 'Add credit',
+          'targetEntityType' => 'commerce_order',
+          'configuration' => ['pattern' => '[commerce_order:uuid]-[pattern:number]']
+        ]);
+        $number_pattern->save();
+      }
+
+      // Get or create the order type.
+      $order_type_storage = $this->getEntityTypeManager()
+        ->getStorage('commerce_order_type');
+      $order_type = $order_type_storage->load('add_credit');
+
+      if (!$order_type) {
+        $order_type = $order_type_storage->create([
+          'status' => 1,
+          'id' => 'add_credit',
+          'label' => 'Add credit',
+          'workflow' => 'order_default',
+          'numberPattern' => $number_pattern->id(),
+        ]);
+        $order_type->save();
+      }
+      $order_type_id = $order_type->id();
+    }
+
     // Get or create the order item type.
     $order_item_type_storage = $this->getEntityTypeManager()
       ->getStorage('commerce_order_item_type');
@@ -68,7 +105,7 @@ class AddCreditProductType extends RequirementBase {
         'status' => 1,
         'id' => 'add_credit',
         'label' => 'Add credit',
-        'orderType' => 'default',
+        'orderType' => $order_type_id ? $order_type_id : 'default',
         'purchasableEntityType' => 'commerce_product_variation',
       ]);
       $order_item_type->save();
@@ -137,6 +174,21 @@ class AddCreditProductType extends RequirementBase {
       $component['label'] = 'hidden';
       $display->setComponent('variations', $component)
         ->save();
+
+      // For ApigeeX, Commerce product variation manage display changes.
+      if (\Drupal::service('apigee_m10n.monetization')->isOrganizationApigeeXorHybrid()) {
+        $view_mode = EntityViewDisplay::create([
+          'targetEntityType' => 'commerce_product_variation',
+          'bundle' => $variation_type->id(),
+          'mode' => 'default',
+          'status' => TRUE,
+        ]);
+        $view_mode->save();
+        $view_mode->setComponent('title', ['weight' => 1, 'label' => 'hidden'])
+          ->removeComponent('list_price')
+          ->removeComponent('price')
+          ->save();
+      }
     }
   }
 

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
@@ -20,6 +20,7 @@
 namespace Drupal\apigee_m10n_add_credit\Plugin\Requirement\Requirement;
 
 use Apigee\Edge\Api\Monetization\Controller\SupportedCurrencyController;
+use Apigee\Edge\Api\ApigeeX\Controller\SupportedCurrencyController as ApigeeXSupportedCurrencyController;
 use Apigee\Edge\Api\Monetization\Entity\SupportedCurrencyInterface;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use Drupal\apigee_m10n\ApigeeEdgeSdkConnectorTrait;
@@ -111,7 +112,12 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
       $organization_id = $this->getApigeeEdgeSdkConnector()->getOrganization();
       $client = $this->getApigeeEdgeSdkConnector()->getClient();
 
-      $supported_currency_controller = new SupportedCurrencyController($organization_id, $client);
+      if (\Drupal::service('apigee_m10n.monetization')->isOrganizationApigeeXorHybrid()) {
+        $supported_currency_controller = new ApigeeXSupportedCurrencyController($organization_id, $client);
+      }
+      else {
+        $supported_currency_controller = new SupportedCurrencyController($organization_id, $client);
+      }
 
       // Filter out currencies with products.
       $this->supportedCurrencies = array_filter($supported_currency_controller->getEntities(), function (SupportedCurrencyInterface $currency) {

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditConfigFormTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditConfigFormTest.php
@@ -48,6 +48,8 @@ class AddCreditConfigFormTest extends AddCreditFunctionalTestBase {
   public function setUp() {
     parent::setUp();
 
+    $this->warmOrganizationCache();
+
     $this->signInAsAdmin();
 
     $this->assertNoClientError();
@@ -73,7 +75,6 @@ class AddCreditConfigFormTest extends AddCreditFunctionalTestBase {
    * @covers \Drupal\apigee_m10n_add_credit\Form\AddCreditConfigForm::submitForm
    */
   public function testConfigFormUi() {
-    $this->warmOrganizationCache();
     $this->queueMockResponses(['get-supported-currencies']);
     $this->drupalGet(Url::fromRoute('apigee_m10n_add_credit.settings.add_credit')->toString());
 

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditProductAdminTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditProductAdminTest.php
@@ -40,6 +40,8 @@ class AddCreditProductAdminTest extends AddCreditFunctionalTestBase {
   public function setUp() {
     parent::setUp();
 
+    $this->warmOrganizationCache();
+
     $this->signInAsAdmin();
 
     $this->assertNoClientError();

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditProductCheckoutTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/AddCreditProductCheckoutTest.php
@@ -53,6 +53,8 @@ class AddCreditProductCheckoutTest extends AddCreditFunctionalTestBase {
   public function setUp() {
     parent::setUp();
 
+    $this->warmOrganizationCache();
+
     // Create the developer account.
     $this->developer = $this->signIn(['add credit to own developer prepaid balance']);
     $this->assertNoClientError();

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditCustomAmountTest.php
@@ -50,6 +50,8 @@ class AddCreditCustomAmountTest extends AddCreditFunctionalJavascriptTestBase {
   public function setUp() {
     parent::setUp();
 
+    $this->warmOrganizationCache();
+
     $this->developer = $this->signInAsAdmin();
 
     $this->assertNoClientError();

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/BalanceAdjustmentJobKernelTest.php
@@ -90,6 +90,8 @@ class BalanceAdjustmentJobKernelTest extends MonetizationKernelTestBase {
   public function setUp() {
     parent::setUp();
 
+    $this->warmOrganizationCache();
+
     $this->installSchema('system', ['sequences']);
     $this->installSchema('apigee_edge', ['apigee_edge_job']);
     $this->installSchema('user', ['users_data']);

--- a/src/ApigeeSdkControllerFactory.php
+++ b/src/ApigeeSdkControllerFactory.php
@@ -25,6 +25,7 @@ use Apigee\Edge\Api\ApigeeX\Controller\ApiProductControllerInterface as ApixProd
 use Apigee\Edge\Api\ApigeeX\Controller\RatePlanController as ApigeexRatePlanController;
 use Apigee\Edge\Api\ApigeeX\Controller\RatePlanControllerInterface as ApigeexRatePlanControllerInterface;
 use Apigee\Edge\Api\ApigeeX\Controller\DeveloperAcceptedRatePlanController as ApigeexDeveloperAcceptedRatePlanController;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperBillingTypeController;
 use Apigee\Edge\Api\Monetization\Controller\ApiPackageController;
 use Apigee\Edge\Api\Monetization\Controller\ApiPackageControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\ApiProductController;
@@ -35,12 +36,16 @@ use Apigee\Edge\Api\Monetization\Controller\DeveloperAcceptedRatePlanController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperPrepaidBalanceController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperPrepaidBalanceControllerInterface;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperPrepaidBalanceController as ApigeexDeveloperPrepaidBalanceController;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperPrepaidBalanceControllerInterface as ApigeexDeveloperPrepaidBalanceControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperReportDefinitionController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperReportDefinitionControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\RatePlanController;
 use Apigee\Edge\Api\Monetization\Controller\RatePlanControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\SupportedCurrencyController;
 use Apigee\Edge\Api\Monetization\Controller\SupportedCurrencyControllerInterface;
+use Apigee\Edge\Api\ApigeeX\Controller\SupportedCurrencyController as ApigeeXSupportedCurrencyController;
+use Apigee\Edge\Api\ApigeeX\Controller\SupportedCurrencyControllerInterface as ApigeeXSupportedCurrencyControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\TermsAndConditionsController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperTermsAndConditionsController;
 use Apigee\Edge\Api\Monetization\Controller\TermsAndConditionsControllerInterface;
@@ -128,6 +133,36 @@ class ApigeeSdkControllerFactory implements ApigeeSdkControllerFactoryInterface 
       );
     }
     return $this->controllers[__FUNCTION__][$developer_email];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function developerBalancexController(UserInterface $developer): ApigeexDeveloperPrepaidBalanceControllerInterface {
+    $developer_email = $developer->getEmail();
+    if (empty($this->controllers[__FUNCTION__][$developer_email])) {
+      // Don't assume the bucket has been initialized.
+      $this->controllers[__FUNCTION__] = $this->controllers[__FUNCTION__] ?? [];
+      // Create a new balance controller.
+      $this->controllers[__FUNCTION__][$developer_email] = new ApigeexDeveloperPrepaidBalanceController(
+        $developer_email,
+        $this->getOrganization(),
+        $this->getClient()
+      );
+    }
+    return $this->controllers[__FUNCTION__][$developer_email];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function developerBillingTypeController(string $developer_id): DeveloperBillingTypeController {
+
+    if (empty($this->controllers[__FUNCTION__])) {
+      // Create a new developer controller.
+      $this->controllers[__FUNCTION__] = new DeveloperBillingTypeController($developer_id, $this->getOrganization(), $this->getClient());
+    }
+    return $this->controllers[__FUNCTION__];
   }
 
   /**
@@ -265,6 +300,20 @@ class ApigeeSdkControllerFactory implements ApigeeSdkControllerFactoryInterface 
     if (empty($this->controllers[__FUNCTION__])) {
       // Create a new org controller.
       $this->controllers[__FUNCTION__] = new SupportedCurrencyController(
+        $this->getOrganization(),
+        $this->getClient()
+      );
+    }
+    return $this->controllers[__FUNCTION__];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportedCurrencyxController(): ApigeeXSupportedCurrencyControllerInterface {
+    if (empty($this->controllers[__FUNCTION__])) {
+      // Create a new org controller.
+      $this->controllers[__FUNCTION__] = new ApigeeXSupportedCurrencyController(
         $this->getOrganization(),
         $this->getClient()
       );

--- a/src/ApigeeSdkControllerFactoryInterface.php
+++ b/src/ApigeeSdkControllerFactoryInterface.php
@@ -27,12 +27,15 @@ use Apigee\Edge\Api\Monetization\Controller\ApiProductControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\CompanyPrepaidBalanceControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperAcceptedRatePlanController;
 use Apigee\Edge\Api\ApigeeX\Controller\DeveloperAcceptedRatePlanController as ApigeeXDeveloperAcceptedRatePlanController;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperBillingTypeController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperController;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperPrepaidBalanceControllerInterface;
+use Apigee\Edge\Api\ApigeeX\Controller\DeveloperPrepaidBalanceControllerInterface as ApigeeXDeveloperPrepaidBalanceControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperReportDefinitionControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\RatePlanControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\DeveloperTermsAndConditionsController;
 use Apigee\Edge\Api\Monetization\Controller\SupportedCurrencyControllerInterface;
+use Apigee\Edge\Api\ApigeeX\Controller\SupportedCurrencyControllerInterface as ApigeeXSupportedCurrencyControllerInterface;
 use Apigee\Edge\Api\Monetization\Controller\TermsAndConditionsControllerInterface;
 use Drupal\user\UserInterface;
 
@@ -70,6 +73,28 @@ interface ApigeeSdkControllerFactoryInterface {
    *   The controller.
    */
   public function developerBalanceController(UserInterface $developer): DeveloperPrepaidBalanceControllerInterface;
+
+  /**
+   * Creates a ApigeeX developer prepaid balance controller.
+   *
+   * @param \Drupal\user\UserInterface $developer
+   *   The developer drupal user.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Controller\DeveloperPrepaidBalanceControllerInterface
+   *   The controller.
+   */
+  public function developerBalancexController(UserInterface $developer): ApigeexDeveloperPrepaidBalanceControllerInterface;
+
+  /**
+   * Creates a ApigeeX developer billing type controller.
+   *
+   * @param string $developer_id
+   *   The developer email address.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Controller\DeveloperBillingTypeController
+   *   The controller.
+   */
+  public function developerBillingTypeController(string $developer_id): DeveloperBillingTypeController;
 
   /**
    * Creates a company prepaid balance controller.
@@ -159,6 +184,14 @@ interface ApigeeSdkControllerFactoryInterface {
    *   The controller.
    */
   public function supportedCurrencyController(): SupportedCurrencyControllerInterface;
+
+  /**
+   * Creates a supported currency controller.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Controller\SupportedCurrencyControllerInterface
+   *   The controller.
+   */
+  public function supportedCurrencyxController(): ApigeeXSupportedCurrencyControllerInterface;
 
   /**
    * Creates a prepaid balance reports controller.

--- a/src/Controller/BillingTypeController.php
+++ b/src/Controller/BillingTypeController.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\apigee_m10n\ApigeeSdkControllerFactoryInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\apigee_m10n\MonetizationInterface;
+
+/**
+ * An example controller.
+ */
+class BillingTypeController extends ControllerBase {
+
+  /**
+   * Apigee Monetization base service.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * BillingTypeController constructor.
+   *
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   Monetization service.
+   */
+  public function __construct(MonetizationInterface $monetization) {
+    $this->monetization = $monetization;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('apigee_m10n.monetization')
+    );
+  }
+
+  /**
+   * Checks current users access to Billing type page.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Grants access to the route if passed permissions are present.
+   */
+  public function access(RouteMatchInterface $route_match, AccountInterface $account) {
+    $user = $route_match->getParameter('user');
+    try {
+      $developer_billingtype = $this->monetization->getBillingtype($user);
+    }
+    catch (\Exception $e) {
+      return AccessResult::forbidden('Developer does not exist.');
+    }
+
+    if (!$this->monetization->isOrganizationApigeeXorHybrid()) {
+      return AccessResult::forbidden('Only accessible for ApigeeX organization.');
+    }
+
+    return AccessResult::allowedIf(
+      $account->hasPermission('view any billing details') ||
+      ($account->hasPermission('view own billing details') && $account->id() === $user->id())
+    );
+  }
+
+  /**
+   * Displays the user/developers billing type.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The drupal user/developer.
+   *
+   * @return array
+   *   The billing type array.
+   */
+  public function myBillingType(UserInterface $user) {
+    $developer_billing_type = $this->monetization->getBillingtype($user);
+    $build = [
+      '#type' => 'Page',
+      '#prefix' => 'Billing Type : ',
+      '#markup' => $developer_billing_type ? $developer_billing_type : 'Not Specified (Defaults to Postpaid)',
+    ];
+    return $build;
+  }
+
+}

--- a/src/Controller/PrepaidBalanceXController.php
+++ b/src/Controller/PrepaidBalanceXController.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2018 Google Inc.
+ * Copyright 2021 Google Inc.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License version 2 as published by the
@@ -28,30 +28,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * Controller for team balances.
  */
-class PrepaidBalanceController extends PrepaidBalanceControllerBase {
-
-  /**
-   * Redirect to the user's prepaid balances page.
-   *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Gets a redirect to the users's balance page.
-   */
-  public function myRedirect(): RedirectResponse {
-    if ($this->monetization->isOrganizationApigeeXorHybrid()) {
-      return $this->redirect(
-        'apigee_monetization.xbilling',
-        ['user' => $this->currentUser->id()],
-        ['absolute' => TRUE]
-      );
-    }
-    else {
-      return $this->redirect(
-        'apigee_monetization.billing',
-        ['user' => $this->currentUser->id()],
-        ['absolute' => TRUE]
-      );
-    }
-  }
+class PrepaidBalanceXController extends PrepaidBalanceXControllerBase {
 
   /**
    * Checks current users access and if developer is prepaid.
@@ -67,12 +44,12 @@ class PrepaidBalanceController extends PrepaidBalanceControllerBase {
    */
   public function access(RouteMatchInterface $route_match, AccountInterface $account) {
     $user = $route_match->getParameter('user');
-    if (!$this->monetization->isDeveloperPrepaid($user)) {
+
+    if (!$this->monetization->isDeveloperPrepaidX($user)) {
       return AccessResult::forbidden('Developer is not prepaid.');
     }
-
-    if ($this->monetization->isOrganizationApigeeXorHybrid()) {
-      return AccessResult::forbidden('Not accessible for ApigeeX organization');
+    if (!$this->monetization->isOrganizationApigeeXorHybrid()) {
+      return AccessResult::forbidden('Only accessible for ApigeeX organization');
     }
     return AccessResult::allowedIf(
       $account->hasPermission('view any prepaid balance') ||
@@ -111,15 +88,8 @@ class PrepaidBalanceController extends PrepaidBalanceControllerBase {
   /**
    * {@inheritdoc}
    */
-  protected function canAccessDownloadReport() {
-    return $this->currentUser->hasPermission('download prepaid balance reports');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function load() {
-    return ($list = $this->monetization->getDeveloperPrepaidBalances($this->entity, new \DateTimeImmutable('now'))) ? $list : [];
+    return ($list = $this->monetization->getDeveloperPrepaidBalancesX($this->entity)) ? $list : [];
   }
 
 }

--- a/src/Controller/PrepaidBalanceXControllerBase.php
+++ b/src/Controller/PrepaidBalanceXControllerBase.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Controller;
+
+use Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface;
+use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\apigee_m10n\Form\PrepaidBalanceConfigForm;
+use Drupal\apigee_m10n\Form\PrepaidBalanceRefreshForm;
+use Drupal\apigee_m10n\MonetizationInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Prepaid balance controller base.
+ *
+ * This is modeled after an entity list builder with some additions.
+ * See: `\Drupal\Core\Entity\EntityListBuilder`
+ */
+abstract class PrepaidBalanceXControllerBase extends ControllerBase implements PrepaidBalanceXControllerInterface {
+
+  /**
+   * The entity for this report.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * Apigee Monetization utility service.
+   *
+   * @var \Drupal\apigee_m10n\MonetizationInterface
+   */
+  protected $monetization;
+
+  /**
+   * The Apigee SDK connector.
+   *
+   * @var \Drupal\apigee_edge\SDKConnectorInterface
+   */
+  protected $sdk_connector;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Drupal core messenger service (for adding flash messages).
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * BillingController constructor.
+   *
+   * @param \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector
+   *   The `apigee_edge.sdk_connector` service.
+   * @param \Drupal\apigee_m10n\MonetizationInterface $monetization
+   *   The `apigee_m10n.monetization` service.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Drupal core messenger service (for adding flash messages).
+   */
+  public function __construct(SDKConnectorInterface $sdk_connector, MonetizationInterface $monetization, FormBuilderInterface $form_builder, AccountInterface $current_user, ModuleHandlerInterface $module_handler, MessengerInterface $messenger) {
+    $this->sdk_connector = $sdk_connector;
+    $this->monetization = $monetization;
+    $this->currentUser = $current_user;
+    $this->formBuilder = $form_builder;
+    $this->moduleHandler = $module_handler;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('apigee_edge.sdk_connector'),
+      $container->get('apigee_m10n.monetization'),
+      $container->get('form_builder'),
+      $container->get('current_user'),
+      $container->get('module_handler'),
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    // Sanitize the entity type for a type specific wrapper class.
+    $type_class = preg_replace('/[^a-z]+/', '-', $this->entity->getEntityTypeId());
+
+    $build = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['apigee-m10n-prepaid-balance-wrapper', "apigee-m10n-{$type_class}-prepaid-balance-wrapper"],
+      ],
+      '#attached' => [
+        'library' => [
+          'apigee_m10n/prepaid_balance',
+        ],
+      ],
+    ];
+
+    // Add a refresh cache form.
+    if ($this->canRefreshBalance()) {
+      $build['refresh_form'] = $this->formBuilder()->getForm(PrepaidBalanceRefreshForm::class, $this->getCacheTags($this->entity));
+    }
+
+    $build['table'] = [
+      '#type' => 'table',
+      '#header' => $this->buildHeader(),
+      '#caption' => $this->getTitle(),
+      '#rows' => [],
+      '#empty' => $this->t('There are no balances available for this @label.', ['@label' => strtolower($this->entity->getEntityType()->getLabel())]),
+      '#cache' => [
+        'contexts' => ['url.path'],
+        'tags' => $this->getCacheTags($this->entity),
+        'max-age' => $max_age = $this->getCacheMaxAge(),
+        'keys' => [static::getCacheId($this->entity, 'prepaid_balances')],
+      ],
+    ];
+
+    // Convert wait time to miliseconds as the last credited time is miliseconds.
+    $wait_time_in_miliseconds = \Drupal::config('apigee_m10n_add_credit.general_settings.config')->get('wait_time') * 1000;
+    $utc = new \DateTimeZone('UTC');
+    $currentTimestamp = (new \DateTimeImmutable())->setTimezone($utc);
+    $currentTimestamp = ($currentTimestamp->getTimestamp() . $currentTimestamp->format('v'));
+    $time_to_wait = '';
+    foreach ($this->getDataFromCache($this->entity, 'prepaid_balances', [$this, 'load']) as $balance) {
+
+      /** @var \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface $balance */
+      if ($row = $this->buildRow($balance)) {
+        $build['table']['#rows'][strtolower($balance->getBalance()->getCurrencyCode())] = $row;
+
+        $time_to_wait = $balance->getlastCreditTime() + $wait_time_in_miliseconds;
+        if ($time_to_wait > $currentTimestamp) {
+          $build['table']['#rows'][strtolower($balance->getBalance()->getCurrencyCode())]['#attributes']['class'] = 'disable-add-credit';
+          $seconds = floor(($time_to_wait - $currentTimestamp) / 1000);
+          $minutes = floor(($seconds / 60) % 60);
+          // If wait time set is less than 60 seconds, then the text is shown.
+          // minutes+1 is added to avoid showing seconds.
+          $minutes = ($wait_time_in_miliseconds <= 60000) ? "few seconds" : $minutes + 1 . ' mins';
+          $this->messenger->addWarning($this->t('**Add credit is disabled for @mins for currency @currency ', ['@mins' => $minutes, '@currency' => $balance->getBalance()->getCurrencyCode()]));
+
+        }
+      }
+    }
+
+    // Allow other modules to alter this build.
+    $this->moduleHandler->alter('apigee_m10n_prepaid_balance_list', $build, $this->entity);
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle() {
+    return $this->t('Current prepaid balance');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    return [
+      'currency' => $this->t('Account Currency'),
+      'current_balance' => $this->t('Current Balance'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(PrepaidBalanceInterface $balance) {
+
+    $currency_code = $balance->getBalance()->getCurrencyCode();
+    return [
+      'class' => ["apigee-balance-row-{$balance->getBalance()->getCurrencyCode()}"],
+      'data' => [
+        'currency' => $currency_code,
+        'current_balance' => $this->formatCurrency(($balance->getBalance()->getUnits() + $balance->getBalance()->getNanos()), $currency_code,),
+      ],
+    ];
+  }
+
+  /**
+   * Format an amount using the `monetization` service.
+   *
+   * See: \Drupal\apigee_m10n\MonetizationInterface::formatCurrency().
+   *
+   * @param string $amount
+   *   The money amount.
+   * @param string $currency_code
+   *   Currency code.
+   *
+   * @return string
+   *   The formatted amount as a string.
+   */
+  protected function formatCurrency($amount, $currency_code) {
+    return $this->monetization->formatCurrency($amount, $currency_code);
+  }
+
+  /**
+   * Helper to check if user has access to refresh prepaid balance.
+   *
+   * @return bool
+   *   TRUE if user can refresh balance.
+   */
+  abstract protected function canRefreshBalance();
+
+  /**
+   * Loads the balances for the listing.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface[]|array
+   *   A list of apigee monetization prepaid balance entities.
+   *
+   * @throws \Exception
+   */
+  abstract public function load();
+
+  /**
+   * Returns the cache max age.
+   *
+   * @return int
+   *   The cache max age.
+   */
+  protected function getCacheMaxAge() {
+    // Get the max-age from config.
+    if ($config = $this->config(PrepaidBalanceConfigForm::CONFIG_NAME)) {
+      return $config->get('cache.max_age');
+    }
+
+    return 0;
+  }
+
+  /**
+   * Helper to retrieve data from cache.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $suffix
+   *   The cache id suffix.
+   * @param callable $callback
+   *   The callback if not in cache.
+   *
+   * @return mixed
+   *   The data.
+   */
+  protected function getDataFromCache(EntityInterface $entity, string $suffix, callable $callback) {
+    $max_age = $this->getCacheMaxAge();
+
+    // If caching is disable, run callback and return.
+    if ($max_age == 0) {
+      return $callback();
+    }
+
+    $cid = $this->getCacheId($entity, $suffix);
+
+    // Check cache.
+    if ($cache = $this->cache()->get($cid)) {
+      return $cache->data;
+    }
+
+    $data = $callback();
+    $this->cache()
+      ->set($cid, $data, time() + $max_age, $this->getCacheTags($entity));
+
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCacheTags(EntityInterface $entity) {
+    return [
+      static::CACHE_PREFIX,
+      static::getCacheId($entity),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCacheId(EntityInterface $entity, $suffix = NULL) {
+    return static::CACHE_PREFIX . ":{$entity->getEntityTypeId()}:{$entity->id()}" . ($suffix ? ":{$suffix}" : '');
+  }
+
+}

--- a/src/Controller/PrepaidBalanceXControllerInterface.php
+++ b/src/Controller/PrepaidBalanceXControllerInterface.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n\Controller;
+
+use Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Controller for balances.
+ *
+ * This is modeled after an entity list builder with some additions.
+ * See: `\Drupal\Core\Entity\EntityListBuilderInterface`.
+ */
+interface PrepaidBalanceXControllerInterface {
+
+  /**
+   * Cache prefix that is used for cache tags for this controller.
+   */
+  const CACHE_PREFIX = 'apigee.monetization.prepaid_balance';
+
+  /**
+   * View prepaid balance and account statements for teams.
+   *
+   * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   A render array or a redirect response.
+   *
+   * @throws \Exception
+   */
+  public function render();
+
+  /**
+   * Gets the title of the page.
+   */
+  public function getTitle();
+
+  /**
+   * Builds the header row for the entity listing.
+   *
+   * @return array
+   *   A render array structure of header strings.
+   *
+   * @see \Drupal\Core\Entity\EntityListBuilder::render()
+   */
+  public function buildHeader();
+
+  /**
+   * Builds a row for an entity in the entity listing.
+   *
+   * @param \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface $balance
+   *   The SDK balance entity for this row of the list.
+   *
+   * @return array
+   *   A render array structure of fields for this entity.
+   *
+   * @see \Drupal\Core\Entity\EntityListBuilder::render()
+   */
+  public function buildRow(PrepaidBalanceInterface $balance);
+
+  /**
+   * Loads the balances for the listing.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface[]
+   *   A list of apigee monetization prepaid balance entities.
+   *
+   * @throws \Exception
+   */
+  public function load();
+
+  /**
+   * Helper to get the billing cache tags.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   The cache tags.
+   */
+  public static function getCacheTags(EntityInterface $entity);
+
+  /**
+   * Helper to get the cache id.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param null $suffix
+   *   The suffix for the cache id.
+   *
+   * @return string
+   *   The cache id.
+   */
+  public static function getCacheId(EntityInterface $entity, $suffix = NULL);
+
+}

--- a/src/Entity/Access/RatePlanAccessControlHandler.php
+++ b/src/Entity/Access/RatePlanAccessControlHandler.php
@@ -84,11 +84,21 @@ class RatePlanAccessControlHandler extends EntityAccessControlHandlerBase implem
     // does not belong to rate_plan category.
     /** @var \Drupal\apigee_edge\Entity\DeveloperInterface $developer */
     if ($rate_plan instanceof DeveloperCategoryRatePlanInterface) {
-      if (($category = $rate_plan->getDeveloperCategory()) && ($developer = $this->entityTypeManager->getStorage('developer')->load($account->getEmail()))) {
-        return AccessResult::allowedIf(($developer_category = $developer->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY')) && ($category->id() === $developer_category))
-          ->andIf(AccessResult::allowedIfHasPermission($account, "$operation rate_plan"));
+      $category = $rate_plan->getDeveloperCategory();
+      if ($category === NULL) {
+        return AccessResult::forbidden("Missing developer category reference on {$rate_plan->id()} rate plan, {$operation} is not allowed.");
       }
-      return AccessResult::forbidden("User {$developer->getEmail()} missing required developer category.");
+      else {
+        $developer = $this->entityTypeManager->getStorage('developer')->load($account->getEmail());
+        if ($developer) {
+          $developer_category = $developer->decorated()->getAttributeValue('MINT_DEVELOPER_CATEGORY') ?? '';
+          return AccessResult::allowedIf($category->id() === $developer_category)->andIf(AccessResult::allowedIfHasPermission($account, "$operation rate_plan"));
+        }
+        else {
+          // Should not happen.
+          return AccessResult::forbidden("Could not fetch developer information for {$account->getEmail()}.");
+        }
+      }
     }
 
     // If rate plan is a developer rate plan, and the assigned developer is

--- a/src/Entity/Property/RevenueShareTypePropertyAwareDecoratorTrait.php
+++ b/src/Entity/Property/RevenueShareTypePropertyAwareDecoratorTrait.php
@@ -28,14 +28,14 @@ trait RevenueShareTypePropertyAwareDecoratorTrait {
    * {@inheritdoc}
    */
   public function getRevenueShareType(): ?string {
-    return $this->decorated->getBillingPeriod();
+    return $this->decorated->getRevenueShareType();
   }
 
   /**
    * {@inheritdoc}
    */
   public function setRevenueShareType(string $revenueShareType): void {
-    $this->decorated->setBillingPeriod($revenueShareType);
+    $this->decorated->setRevenueShareType($revenueShareType);
   }
 
 }

--- a/src/MonetizationInterface.php
+++ b/src/MonetizationInterface.php
@@ -24,6 +24,7 @@ use Apigee\Edge\Api\Management\Entity\OrganizationInterface;
 use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\TermsAndConditionsInterface;
 use Apigee\Edge\Api\Monetization\Structure\LegalEntityTermsAndConditionsHistoryItem;
+use Apigee\Edge\Api\ApigeeX\Entity\DeveloperBillingType;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -100,6 +101,19 @@ interface MonetizationInterface {
    *   The balance list or null if no balances are available.
    */
   public function getDeveloperPrepaidBalances(UserInterface $developer, \DateTimeImmutable $billingDate): ?array;
+
+  /**
+   * Get's the prepaid balance for a developer.
+   *
+   * Takes in a developer mail address and returns an array of prepaid balances.
+   *
+   * @param \Drupal\user\UserInterface $developer
+   *   The developer user.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Entity\PrepaidBalanceInterface[]
+   *   The balance list or empty array if no balances are available.
+   */
+  public function getDeveloperPrepaidBalancesX(UserInterface $developer): ?array;
 
   /**
    * Get's the prepaid balance for a team.
@@ -252,6 +266,41 @@ interface MonetizationInterface {
    *   True if developer is prepaid.
    */
   public function isDeveloperPrepaid(UserInterface $account): bool;
+
+  /**
+   * Returns true if developer billing type is prepaid, false if postpaid.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   The developer account.
+   *
+   * @return bool
+   *   True if developer is prepaid.
+   */
+  public function isDeveloperPrepaidX(UserInterface $account): bool;
+
+  /**
+   * Updates the billing type of the developer.
+   *
+   * @param string $developer_email
+   *   The developer email ID.
+   * @param string $billingtype
+   *   The developer billing type.
+   *
+   * @return \Apigee\Edge\Api\ApigeeX\Entity\DeveloperBillingType
+   *   Billing type entity.
+   */
+  public function updateBillingtype(string $developer_email, string $billingtype): DeveloperBillingType;
+
+  /**
+   * Returns the billing type of the developer.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The developer account.
+   *
+   * @return string|null
+   *   Billing type.
+   */
+  public function getBillingtype(UserInterface $user): ?string;
 
   /**
    * Returns true if current organization is ApigeeX, false if otherwise.

--- a/src/Plugin/Field/FieldFormatter/ConsumptionPricingRatesFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ConsumptionPricingRatesFormatter.php
@@ -95,6 +95,25 @@ class ConsumptionPricingRatesFormatter extends FormatterBase {
     $fee_currency_code = $fee_details->getCurrencyCode();
     $fee_units = $fee_details->getUnits();
     $fee_nanos = $fee_details->getNanos();
+    $fee_start = $detail->getStart();
+    $fee_end = $detail->getEnd();
+
+    $multipleConsumptionText = '';
+    $singleConsumptionText = '';
+    if (empty($fee_start) && empty($fee_end)) {
+      $singleConsumptionText = $fee_currency_code . ' ' . ($fee_units + $fee_nanos);
+    }
+    else {
+      $endUnitStr = $fee_end ? 'up to' : '';
+      $start = $fee_start ? $fee_start : 0;
+      $multiple_consumption_template = 'Greater than @start @endUnitStr @end';
+      // Build the "Consumption text".
+      $multipleConsumptionText = $this->t($multiple_consumption_template, [
+        '@start' => $start,
+        '@endUnitStr' => $endUnitStr,
+        '@end' => $fee_end,
+      ]);
+    }
 
     return [
       '#theme' => 'rate_plan_consumption_rates',
@@ -102,6 +121,8 @@ class ConsumptionPricingRatesFormatter extends FormatterBase {
       '#fee_currency_code' => $fee_currency_code,
       '#fee_units' => $fee_units,
       '#fee_nanos' => $fee_nanos,
+      '#multipleConsumptionText' => $multipleConsumptionText,
+      '#singleConsumptionText' => $singleConsumptionText,
       '#entity' => $item->getEntity(),
       '#attached' => ['library' => ['apigee_m10n/rate_plan.details_field']],
     ];

--- a/src/Plugin/Field/FieldFormatter/RevenueShareRatesFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/RevenueShareRatesFormatter.php
@@ -90,10 +90,33 @@ class RevenueShareRatesFormatter extends FormatterBase {
   protected function viewValue(FieldItemInterface $item) {
     /** @var \Apigee\Edge\Api\ApigeeX\Structure\RevenueShareRates $detail */
     $detail = $item->value;
+    $revenueSharePercentage = $detail->getSharePercentage();
+    $start = $detail->getStart();
+    $end = $detail->getEnd();
+
+    $singleShareText = '';
+    $multipleShareText = '';
+    if (empty($start) && empty($end)) {
+      $singleShareText = $revenueSharePercentage;
+    }
+    else {
+      $endUnitStr = $end ? 'up to' : '';
+      $start = $start ? $start : 0;
+      $multipleShareTextTemplate = 'Greater than @start @endUnitStr @end';
+      // Build the "Consumption te" text.
+      $multipleShareText = $this->t($multipleShareTextTemplate, [
+        '@start' => $start,
+        '@endUnitStr' => $endUnitStr,
+        '@end' => $end,
+      ]);
+    }
 
     return [
       '#theme' => 'rate_plan_revenue_rates',
       '#detail' => $detail,
+      '#revenueSharePercentage' => $revenueSharePercentage,
+      '#singleShareText' => $singleShareText,
+      '#multipleShareText' => $multipleShareText,
       '#entity' => $item->getEntity(),
       '#attached' => ['library' => ['apigee_m10n/rate_plan.details_field']],
     ];

--- a/templates/apigee-entity--xrate-plan.html.twig
+++ b/templates/apigee-entity--xrate-plan.html.twig
@@ -12,6 +12,7 @@
 
 {% embed 'apigee-entity.html.twig' %}
   {% block content %}
+
     {{ title_prefix }}
     {%- if label and view_mode != 'full' -%}
     {% set apiproductName = content.apiProduct|render|striptags %}
@@ -28,9 +29,97 @@
     {%- else -%}
     {{ title_suffix }}
 
-    <div{{ content_attributes }}>
-      {{ content }}
-    </div>
+      <div class="container py-5">
+        <div class="row">
+          <div class="col-lg-6">
+            <div class="bg-lighter p-4 rounded-lg">
+              {{ content|without(
+                'setupFees',
+                'recurringFees',
+                'consumptionFee',
+                'consumptionPricingRates',
+                'consumptionPricingType',
+                'revenueShareType',
+                'revenueShareRates',
+                'feeFrequency',
+                'paymentFundingModel',
+                'purchase'
+                ) }}
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-lg-6">
+            <div class="rate-plan__card rate-plan__card--fees bg-lighter p-4 my-5 rounded-lg">
+              <h2>{{ 'Fees'|t }}</h2>
+              {{ content.setupFees }}
+              {{ content.recurringFees }}
+              {% if content.recurringFees|render|striptags|trim is not empty %}
+                {{ content.feeFrequency }}
+              {% endif %}
+              {{ content.paymentFundingModel }}
+            </div>
+
+            {% if content.consumptionPricingRates|render|striptags|trim is not empty %}
+              <div class="rate-plan__card rate-plan__card--fees bg-lighter p-4 my-5 rounded-lg">
+                <h2>{{ 'Consumption Fees'|t }}</h2>
+                {{ content.consumptionPricingType }}
+
+                {% if content.consumptionPricingRates[0]['#singleConsumptionText'] %}
+                  {{ content.consumptionPricingRates }}
+                {% else %}
+                  <div class="rate-plan-detail__table px-4 py-2 mt-4 bg-white">
+                    <table class="table table-borderless mb-0">
+                      <thead>
+                        <tr>
+                          <th scope="col">{{ 'Volume Bands'|t }}</th>
+                          <th scope="col">{{ 'Cost per API call'|t }}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {{ content.consumptionPricingRates }}
+                      </tbody>
+                    </table>
+                  </div>
+                {% endif %}
+              </div>
+            {% endif %}
+
+            {% if content.revenueShareRates|render|striptags|trim is not empty %}
+              <div class="rate-plan__card rate-plan__card--fees bg-lighter p-4 my-5 rounded-lg">
+                <h2>{{ 'Revenue Sharing'|t }}</h2>
+                {{ content.revenueShareType }}
+
+              {% if content.revenueShareRates[0]['#singleShareText'] %}
+                  {{ content.revenueShareRates }}
+                {% else %}
+                  <div class="rate-plan-detail__table px-4 py-2 mt-4 bg-white">
+                    <table class="table table-borderless mb-0">
+                      <thead>
+                        <tr>
+                          <th scope="col">{{ 'Volume Bands'|t }}</th>
+                          <th scope="col">{{ 'Developer Share Percentage'|t }}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {{ content.revenueShareRates }}
+                      </tbody>
+                    </table>
+                  </div>
+                {% endif %}
+              </div>
+            {% endif %}
+
+            {% if content.purchase %}
+              <div class="rate-plan__card rate-plan__card--purchase bg-lighter p-4 mt-4 rounded-lg" id="purchase">
+                {{ content.purchase }}
+              </div>
+            {% endif %}
+          </div>
+        </div>
+
+      </div>
     {%- endif -%}
   {% endblock %}
 {% endembed %}

--- a/templates/rate-plan-consumption-rates.html.twig
+++ b/templates/rate-plan-consumption-rates.html.twig
@@ -1,38 +1,25 @@
 {#
 /**
  * @file
- * Default theme implementation to display a apigee rate plan detail.
+ * Default theme implementation to display Consumption fee in detail.
  *
  * Variables:
- * - currencyCode:                  The three-letter currency code defined in ISO 4217.   
+ * - currencyCode:                  The three-letter currency code defined in ISO 4217.
  * - nanos:                         Number of nano (10^-9) units of the amount.
  * - units:                         The whole units of the amount.
+ * - multipleConsumptionText:       Consumption text.
  */
 #}
 
-<div class="rate-plan-detail">
-  <div class="rate-plan-detail__overview rate-plan-detail__list-wrapper">
-    <div class="revshare-rate rate-plan-rates__row">
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__operator">
-          <div class="field__label">{{ "Start"|t }}</div>
-          <div class="field__item">{{ detail.start }}</div>
-        </div>
-      </div>
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__currency">
-          <div class="field__label">{{ "End"|t }}</div>
-          <div class="field__item">{{ detail.end }}</div>
-        </div>
-      </div>
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__currency">
-          <div class="field__label">{{ "Fee"|t }}</div>
-          <div class="field__item">{{ fee_currency_code }}</div>
-          <div class="field__item">{{ fee_units }}</div>
-          <div class="field__item">{{ fee_nanos }}</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+{% if multipleConsumptionText %}
+  <tr>
+    <td>
+      {{ multipleConsumptionText }}
+    </td>
+    <td>
+      {{ fee_currency_code }} {{ fee_units + fee_nanos }}
+    </td>
+  </tr>
+{% else %}
+  {{ singleConsumptionText }}
+{% endif %}

--- a/templates/rate-plan-revenue-rates.html.twig
+++ b/templates/rate-plan-revenue-rates.html.twig
@@ -1,32 +1,25 @@
 {#
 /**
  * @file
- * Default theme implementation to display a apigee revenueShareRates details.       
+ * Default theme implementation to display a apigee revenueShareRates details.
+ *
+ * Variables:
+ * - multipleShareText:             Share text.
+ * - nanos:                         Number of nano (10^-9) units of the amount.
+ * - revenueSharePercentage:        Share percentage
+ * - singleShareText:               Text.
  */
 #}
 
-<div class="rate-plan-detail">
-
-  <div class="rate-plan-detail__overview rate-plan-detail__list-wrapper">
-    <div class="revshare-rate rate-plan-rates__row">
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__operator">
-          <div class="field__label">{{ "Start"|t }}</div>
-          <div class="field__item">{{ detail.start }}</div>
-        </div>
-      </div>
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__currency">
-          <div class="field__label">{{ "End"|t }}</div>
-          <div class="field__item">{{ detail.end }}</div>
-        </div>
-      </div>
-      <div class="rate-plan-rates__column">
-        <div class="field field--inline rate-plan-detail__overview__currency">
-          <div class="field__label">{{ "Share Percentage"|t }}</div>
-          <div class="field__item">{{ detail.sharePercentage }}</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+{% if multipleShareText %}
+  <tr>
+    <td>
+      {{ multipleShareText }}
+    </td>
+    <td>
+      {{ revenueSharePercentage }}
+    </td>
+  </tr>
+{% else %}
+  {{ singleShareText }}
+{% endif %}


### PR DESCRIPTION
Developer category reference can be null on developer category-specific rate plans.

Steps to reproduce:
1. Create a developer category and a rate plan for it.
2. Delete the developer category
3. Open a page that uses this code, the developer category becomes missing (null) on the developer category-specific rate plan therefore it cannot be loaded.