### PR TITLE
Implemented custom hook for sending data to user agent string

### DIFF
--- a/apigee_m10n.module
+++ b/apigee_m10n.module
@@ -21,6 +21,8 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Extension\InfoParser;
+use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\apigee_m10n\Entity\RatePlanInterface;
 
@@ -122,6 +124,21 @@ function apigee_m10n_theme($existing, $type, $theme, $path) {
  */
 function apigee_m10n_form_user_admin_permissions_alter(&$form, FormStateInterface $form_state, $form_id) {
   \Drupal::service('apigee_m10n.monetization')->formUserAdminPermissionsAlter($form, $form_state, $form_id);
+}
+
+/**
+ * Implements hook_user_agent_string_alter().
+ */
+function apigee_m10n_user_agent_string_alter() {
+    $infoParser = new InfoParser();
+    $m10_module_info = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_m10n')->getPathname());
+  
+    if (!isset($m10_module_info['version'])) {
+      $m10_module_info['version'] = '8.x-1.x-dev';
+    }
+    $m10_module_info = $m10_module_info['name'] . '/' . $m10_module_info['version'];
+
+    return $m10_module_info;
 }
 
 /**

--- a/apigee_m10n.module
+++ b/apigee_m10n.module
@@ -134,7 +134,7 @@ function apigee_m10n_user_agent_string_alter() {
     $m10_module_info = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_m10n')->getPathname());
   
     if (!isset($m10_module_info['version'])) {
-      $m10_module_info['version'] = '8.x-1.x-dev';
+      $m10_module_info['version'] = '2.x-dev';
     }
     $m10_module_info = $m10_module_info['name'] . '/' . $m10_module_info['version'];
 


### PR DESCRIPTION
Closes https://github.com/apigee/apigee-edge-drupal/issues/556

Implemented a custom hook in `apigee_edge` module for altering /adding additional user agent string from other modules
This PR adds the monetization module version to user agent string.

Related Client PHP PR - apigee/apigee-client-php#171