### PR TITLE
Set current billing type in switch form for Apigee X

### DIFF
--- a/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
@@ -148,12 +148,12 @@ class BillingTypeForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state, UserInterface $user = NULL) {
     $billingType = ['postpaid' => 'Postpaid' , 'prepaid' => 'Prepaid'];
-
+    $developer_billingtype = $this->monetization->getBillingtype($user);
     $form['billingtype'] = [
       '#type' => 'radios',
       '#title' => $this->t('Billing Type'),
       '#options' => $billingType,
-      '#default_value' => 'postpaid',
+      '#default_value' => $developer_billingtype ? strtolower($developer_billingtype) : 'postpaid',
       '#description' => $this->t('Select the billing type for the user.'),
     ];
 


### PR DESCRIPTION
In this PR by default the current billing type of the developer is selected in billing type switch form.