### PR TITLE
Change in violation type for insufficient fund for Apigee X

### DIFF
--- a/src/Entity/Form/PurchasedProductForm.php
+++ b/src/Entity/Form/PurchasedProductForm.php
@@ -43,14 +43,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PurchasedProductForm extends FieldableEdgeEntityForm {
 
   /**
-   * Developer legal name attribute name.
-   */
-  public const LEGAL_NAME_ATTR = 'MINT_DEVELOPER_LEGAL_NAME';
-
-  /**
    * Insufficient funds API error code.
    */
-  public const INSUFFICIENT_FUNDS_ERROR = 'keymanagement.service.developer_usage_exceeds_balance';
+  public const INSUFFICIENT_FUNDS_ERROR = 'mint.service.developer_usage_exceeds_balance';
   public const DEVELOPER_WALLET_DOES_NOT_EXIST = 'keymanagement.service.developer_wallet_does_not_exist';
 
   public const MY_PURCHASES_PRODUCT_CACHE_TAG = 'apigee_my_purchased_products';
@@ -227,7 +222,7 @@ class PurchasedProductForm extends FieldableEdgeEntityForm {
     catch (\Exception $e) {
       $client_error = $e->getPrevious();
 
-      if (($client_error instanceof ServerErrorException && $client_error->getEdgeErrorCode() === static::INSUFFICIENT_FUNDS_ERROR) || ($client_error instanceof ClientErrorException && $client_error->getEdgeErrorCode() === static::DEVELOPER_WALLET_DOES_NOT_EXIST)) {
+      if (($client_error instanceof ClientErrorException && $client_error->getEdgeErrorCode() === static::INSUFFICIENT_FUNDS_ERROR) || ($client_error instanceof ClientErrorException && $client_error->getEdgeErrorCode() === static::DEVELOPER_WALLET_DOES_NOT_EXIST)) {
 
         $rate_plan = $this->getEntity()->getRatePlan();
         $minimum_amount = $rate_plan->getSetupFeesPriceValue();


### PR DESCRIPTION
There was a change in violation type in the response due to which the text to add credit to the balance was not shown.This happens when the developer don't have enough balance to buy the api product.