### PR TITLE
Changes for billing type switch form and added currency in warning in add credit page.

### DIFF
--- a/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/BillingTypeForm.php
@@ -165,6 +165,11 @@ class BillingTypeForm extends FormBase {
       '#type' => 'submit',
       '#value' => $this->t('Save changes'),
       '#button_type' => 'primary',
+      '#states' => [
+        'disabled' => [
+          ':input[name="billingtype"]' => ['value' => strtolower($developer_billingtype)],
+        ]
+      ]
     ];
     return $form;
   }

--- a/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
@@ -166,10 +166,10 @@ class ConfirmUpdateForm extends ConfirmFormBase {
     // Fetch the billing type of the developer.
     $original = $this->monetization->getBillingtype($this->user);
     if ('prepaid' == strtolower($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
-      return $this->t('Once you change the prepaid developer to postpaid, their existing prepaid balance will appear as a credit transaction.<br>Please ensure this is taken into account when calculating amount due.');
+      return $this->t('If the developer billing type is changed from "prepaid" to "postpaid," any existing prepaid balance will be treated as a credit transaction when calculating amounts due.');
     }
     elseif (('postpaid' == strtolower($original) || !($original))&& 'prepaid' == strtolower($this->billingtype_selected)) {
-      return $this->t('When you change a developer from postpaid to prepaid, please inform them to top-up their balance, to ensure their API calls are not blocked because of insufficient balance.');
+      return $this->t('If the developer billing type is changed from "postpaid" to "prepaid," developers should perform a balance top-up to ensure that API calls are not blocked due to an insufficient balance.');
     }
     elseif (!($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
       return $this->t('The billing type will to switched to Postpaid.');

--- a/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
+++ b/modules/apigee_m10n_add_credit/src/Form/ConfirmUpdateForm.php
@@ -108,14 +108,6 @@ class ConfirmUpdateForm extends ConfirmFormBase {
    *   Grants access to the route if passed permissions are present.
    */
   public function access(RouteMatchInterface $route_match, AccountInterface $account) {
-    $user = $this->user;
-    try {
-      $developer_billingtype = $this->monetization->getBillingtype($user);
-    }
-    catch (\Exception $e) {
-      return AccessResult::forbidden('Developer does not exist.');
-    }
-
     return AccessResult::allowedIf(
       $account->hasPermission('update any billing type')
     );
@@ -164,7 +156,24 @@ class ConfirmUpdateForm extends ConfirmFormBase {
    */
   public function getQuestion() {
 
-    return $this->t('Are you sure you want to change the billing type for user %email?', ['%email' => $this->user->getEmail()]);
+    return $this->t('Are you sure you want to change the billing type for user- %email?', ['%email' => $this->user->getEmail()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    // Fetch the billing type of the developer.
+    $original = $this->monetization->getBillingtype($this->user);
+    if ('prepaid' == strtolower($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('Once you change the prepaid developer to postpaid, their existing prepaid balance will appear as a credit transaction.<br>Please ensure this is taken into account when calculating amount due.');
+    }
+    elseif (('postpaid' == strtolower($original) || !($original))&& 'prepaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('When you change a developer from postpaid to prepaid, please inform them to top-up their balance, to ensure their API calls are not blocked because of insufficient balance.');
+    }
+    elseif (!($original) && 'postpaid' == strtolower($this->billingtype_selected)) {
+      return $this->t('The billing type will to switched to Postpaid.');
+    }
   }
 
 }

--- a/src/Controller/PrepaidBalanceXControllerBase.php
+++ b/src/Controller/PrepaidBalanceXControllerBase.php
@@ -186,7 +186,8 @@ abstract class PrepaidBalanceXControllerBase extends ControllerBase implements P
           // If wait time set is less than 60 seconds, then the text is shown.
           // minutes+1 is added to avoid showing seconds.
           $minutes = ($wait_time_in_miliseconds <= 60000) ? "few seconds" : $minutes + 1 . ' mins';
-          $this->messenger->addWarning($this->t('**Add credit is disabled for @mins ', ['@mins' => $minutes]));
+          $this->messenger->addWarning($this->t('**Add credit is disabled for @mins for currency @currency ', ['@mins' => $minutes, '@currency' => $balance->getBalance()->getCurrencyCode()]));
+
         }
       }
     }


### PR DESCRIPTION
This PR enables the save changes button only when the admin  changes the billing type of the developer also appropriate text will be shown on the confirmation page.This PR also displays the currency along with the wait time on the warning message when the  developer adds credit.