### PR TITLE
[#337]Cannot buy rate plan as a team for rate plan subscribed by developer

### DIFF
--- a/modules/apigee_m10n_teams/src/Entity/Form/TeamPurchasedPlanForm.php
+++ b/modules/apigee_m10n_teams/src/Entity/Form/TeamPurchasedPlanForm.php
@@ -24,11 +24,40 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\apigee_edge_teams\Entity\Team;
 use Drupal\apigee_m10n_teams\Entity\TeamsPurchasedPlanInterface;
+use Drupal\apigee_edge\Entity\Form\FieldableEdgeEntityForm;
 
 /**
  * Team purchased plan entity form.
  */
 class TeamPurchasedPlanForm extends PurchasedPlanForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // If the team has already purchased this plan, show a message instead.
+    /** @var \Drupal\apigee_m10n\Entity\RatePlanInterface $rate_plan */
+
+    if ($this->entity instanceof TeamsPurchasedPlanInterface && $this->entity->isTeamPurchasedPlan()) {
+      // Execute only is called from teams.
+      $team_id = $this->entity->decorated()->getCompany()->id();
+      $monetization = \Drupal::service('apigee_m10n.teams');
+      if (($rate_plan = $this->getEntity()->getRatePlan()) && ($monetization->isTeamAlreadySubscribed($team_id, $rate_plan))) {
+        return [
+          '#markup' => $this->t('You have already purchased %rate_plan.', [
+            '%rate_plan' => $rate_plan->getDisplayName(),
+          ]),
+        ];
+      }
+      $form = FieldableEdgeEntityForm::buildForm($form, $form_state);
+    }
+    else {
+      // Call buildForm of PurchasedPlanForm.
+      $form = parent::buildForm($form, $form_state);
+    }
+
+    return $form;
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeamsInterface.php
@@ -26,6 +26,7 @@ use Apigee\Edge\Api\Monetization\Structure\LegalEntityTermsAndConditionsHistoryI
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\apigee_m10n_teams\Entity\TeamsRatePlan;
 
 /**
  * Interface for the `apigee_m10n.teams` service.
@@ -100,6 +101,19 @@ interface MonetizationTeamsInterface {
    *   The access result or null for non-team routes.
    */
   public function purchasedPlanAccess(EntityInterface $entity, $operation, AccountInterface $account);
+
+  /**
+   * Check if team has already subscribed to the rate plan.
+   *
+   * @param string $team_id
+   *   Team ID.
+   * @param \Drupal\apigee_m10n_teams\Entity\TeamsRatePlan $rate_plan
+   *   Rate plan entity.
+   *
+   * @return bool|null
+   *   Check if team is subscribed to a plan.
+   */
+  public function isTeamAlreadySubscribed(string $team_id, TeamsRatePlan $rate_plan): bool;
 
   /**
    * Check if company accepted latest terms and conditions.

--- a/modules/apigee_m10n_teams/tests/response-templates/get-company-purchased-plans.json.twig
+++ b/modules/apigee_m10n_teams/tests/response-templates/get-company-purchased-plans.json.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- *   GET /v1/mint/organizations/{org_name}/developers/{developer_id}/developer-accepted-rateplans
+ *   GET /v1/mint/organizations/{org_name}/companies/{company_id}/developer-accepted-rateplans
  *
  * Response Code: 200
  */

--- a/modules/apigee_m10n_teams/tests/src/Kernel/Entity/PurchasedRatePlanEntityKernelTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/Entity/PurchasedRatePlanEntityKernelTest.php
@@ -229,6 +229,9 @@ class PurchasedRatePlanEntityKernelTest extends MonetizationTeamsKernelTestBase 
     ]);
     static::assertSame("/teams/{$this->team->id()}/monetization/product-bundle/{$this->product_bundle->id()}/plan/{$this->rate_plan->id()}/purchase", $url->toString());
 
+    $this->stack
+      ->queueMockResponse(['get_company_purchased_plans' => ['purchased_plans' => [$this->purchased_plan->decorated()]]]);
+
     $request = Request::create($url->toString(), 'GET');
     $response = $this->container->get('http_kernel')->handle($request);
 

--- a/modules/apigee_m10n_teams/tests/src/Kernel/Entity/RatePlanEntityKernelTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/Entity/RatePlanEntityKernelTest.php
@@ -131,6 +131,7 @@ class RatePlanEntityKernelTest extends MonetizationTeamsKernelTestBase {
       ->view($rate_plan, 'default');
 
     // Rate plans as rendered.
+    $this->stack->queueMockResponse(['get_company_purchased_plans']);
     $this->setRawContent((string) \Drupal::service('renderer')->renderRoot($build));
 
     // Check the entity label.


### PR DESCRIPTION
Fixes #337 . Now team can subscribe to rate plan even if the developer has subscribed to the same rate plan.