### PR TITLE
Fix for cicle ci update-dependencies-8 and kernel failed test.

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -492,6 +492,7 @@ class RoboFile extends \Robo\Tasks
 
         // Add rules for testing apigee_edge_actions (only for D8).
         $config->require->{"drupal/rules"} = "3.0.0-alpha6";
+        $config->require->{"drupal/typed_data"} = "1.0.0-beta1 as 1.x-dev";
 
       default:
         break;

--- a/modules/apigee_m10n_add_credit/tests/src/Kernel/AddCreditConfigStatusKernelTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Kernel/AddCreditConfigStatusKernelTest.php
@@ -81,6 +81,7 @@ class AddCreditConfigStatusKernelTest extends MonetizationKernelTestBase {
       'system',
     ]);
     $this->installEntitySchema('user');
+    $this->installEntitySchema('path_alias');
     $this->installEntitySchema('commerce_store');
     $this->installEntitySchema('commerce_product');
   }


### PR DESCRIPTION
Fixes #343 .
 Added typed_data 1.0.0-beta1 only for D8 as dev version of typed_data is not compatible with D8 and installed entity schema for 'path_alias' as kernel  test was failing.