### PR TITLE
Bump drupal/apigee_edge requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-bcmath": "*",
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
-        "drupal/apigee_edge": "^2.0.0",
+        "drupal/apigee_edge": "^2.0.2",
         "drupal/core": "^8.9.19 || ^9.0.8",
         "drupal/requirement": "~1.0",
         "apigee/apigee-client-php": "^2.0.12"


### PR DESCRIPTION
Closes #359 

Apigee edge module requirement needs to be upgraded to 2.0.2
Reference (user-agent custom hook) : apigee/apigee-edge-drupal#624