### PR TITLE
Bump Drupal core version requirement to 9.2.13 and removed Drupal 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ defaults: &defaults
   parameters:
     core-version:
       type: integer
-      default: 8
+      default: 9
     instance-type:
       type: string
 
@@ -210,7 +210,7 @@ code_sniffer: &code_sniffer
         working_directory: /var/www/html
         command: &code_sniffer_command |
           cp ./modules/apigee_m10n/.circleci/code-sniffer.sh /var/www/html
-          ./code-sniffer.sh apigee_m10n 8
+          ./code-sniffer.sh apigee_m10n 9
 
     - store_test_results:
         path: /var/www/html/artifacts/phpcs
@@ -230,8 +230,8 @@ code_coverage: &code_coverage
         working_directory: /var/www/html
         command: |
           sudo sed -i 's/^;zend_extension/zend_extension/g' /usr/local/etc/php/conf.d/xdebug.ini
-          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n 8
-          ./code-coverage-stats.sh apigee_m10n 8
+          modules/apigee_m10n/.circleci/update-dependencies.sh apigee_m10n 9
+          ./code-coverage-stats.sh apigee_m10n 9
     - store_artifacts:
         path: /var/www/html/artifacts
 
@@ -239,6 +239,8 @@ code_coverage: &code_coverage
 d9_check: &d9_check
   <<: *defaults
   steps:
+    - run: rm -rf /var/www/html/core
+
     - attach_workspace:
         at: /var/www/html
 
@@ -247,7 +249,7 @@ d9_check: &d9_check
     - run:
         working_directory: /var/www/html
         command: |
-          ./d9.sh apigee_m10n 8
+          ./d9.sh apigee_m10n 9
 
     - store_test_results:
         path: /var/www/html/artifacts/d9
@@ -316,13 +318,13 @@ workflows:
           name: update-dependencies-<< matrix.core-version >> << matrix.instance-type >>
           matrix:
             parameters:
-              core-version: [ 8, 9 ]
+              core-version: [ 9 ]
               instance-type: [ edge, apigeex ]
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >> << matrix.instance-type >>
           matrix:
             parameters:
-              core-version: [ 8, 9 ]
+              core-version: [ 9 ]
               instance-type: [ edge, apigeex ]
           requires:
             - update-dependencies-<< matrix.core-version >> << matrix.instance-type >>
@@ -330,7 +332,7 @@ workflows:
           name: run-functional-tests-<< matrix.core-version >> << matrix.instance-type >>
           matrix:
             parameters:
-              core-version: [ 8, 9 ]
+              core-version: [ 9 ]
               instance-type: [ edge, apigeex ]
           requires:
             - update-dependencies-<< matrix.core-version >> << matrix.instance-type >>
@@ -338,7 +340,7 @@ workflows:
           name: run-functional-js-tests-<< matrix.core-version >> << matrix.instance-type >>
           matrix:
             parameters:
-              core-version: [ 8, 9 ]
+              core-version: [ 9 ]
               instance-type: [ edge, apigeex ]
           requires:
             - update-dependencies-<< matrix.core-version >> << matrix.instance-type >>
@@ -348,19 +350,19 @@ workflows:
             parameters:
               instance-type: [ edge ]
           requires:
-            - update-dependencies-8 << matrix.instance-type >>
+            - update-dependencies-9 << matrix.instance-type >>
       - run-d9-check:
           name: run-d9-check
           matrix:
             parameters:
               instance-type: [ edge ]
           requires:
-            - update-dependencies-8 << matrix.instance-type >>
-      - run-code-coverage:
-          name: run-code-coverage
-          matrix:
-            parameters:
-              instance-type: [ edge ]
-          requires:
-            - update-dependencies-8 << matrix.instance-type >>
-            - run-unit-kernel-tests-8 << matrix.instance-type >>
+            - update-dependencies-9 << matrix.instance-type >>
+#      - run-code-coverage:
+#          name: run-code-coverage
+#          matrix:
+#            parameters:
+#              instance-type: [ edge ]
+#         requires:
+#            - update-dependencies-9 << matrix.instance-type >>
+#            - run-unit-kernel-tests-9 << matrix.instance-type >>

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0",
         "drupal/apigee_edge": "^2.0.2",
-        "drupal/core": "^8.9.19 || ^9.0.8",
+        "drupal/core": "^9.2.13",
         "drupal/requirement": "~1.0",
         "apigee/apigee-client-php": "^2.0.12"
     },
@@ -17,7 +17,7 @@
         "apigee/apigee-mock-client-php": "^1.0",
         "behat/mink-extension": "^2.0",
         "bex/behat-screenshot": "^1.2",
-        "drupal/core-dev": "^8.7 || ^9",
+        "drupal/core-dev": "^9.2.13",
         "drupal/drupal-extension": "master-dev",
         "drush/drush": "^9.0 || ^10.0",
         "mglaman/drupal-check": "^1.1",

--- a/src/EventSubscriber/ValidateMonetizationEnabledSubscriber.php
+++ b/src/EventSubscriber/ValidateMonetizationEnabledSubscriber.php
@@ -23,7 +23,7 @@ use Drupal\apigee_m10n\Monetization;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -61,10 +61,10 @@ class ValidateMonetizationEnabledSubscriber implements EventSubscriberInterface 
   /**
    * If monetization isn't enabled alert the user.
    *
-   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
    *   The event.
    */
-  public function validateMonetizationEnabled(GetResponseEvent $event) {
+  public function validateMonetizationEnabled(RequestEvent $event) {
     /** @var \Symfony\Component\Routing\Route $current_route */
     if (($current_route = $event->getRequest()->get('_route_object')) && ($current_route->hasOption('_apigee_monetization_route'))) {
       if (!$this->monetization->isMonetizationEnabled()) {

--- a/tests/src/Functional/PrepaidBalanceConfigFormTest.php
+++ b/tests/src/Functional/PrepaidBalanceConfigFormTest.php
@@ -70,9 +70,9 @@ class PrepaidBalanceConfigFormTest extends MonetizationFunctionalTestBase {
 
     // Check if config were saved.
     $config = $this->config(PrepaidBalanceConfigForm::CONFIG_NAME);
-    $this->assertEqual(1800, $config->get('cache.max_age'));
+    $this->assertEquals(1800, $config->get('cache.max_age'));
     $this->assertFalse($config->get('enable_insufficient_funds_workflow'));
-    $this->assertEqual(24, $config->get('max_statement_history_months'));
+    $this->assertEquals(24, $config->get('max_statement_history_months'));
   }
 
 }

--- a/tests/src/Functional/PrepaidBalanceReportsDownloadFunctionalTest.php
+++ b/tests/src/Functional/PrepaidBalanceReportsDownloadFunctionalTest.php
@@ -176,8 +176,8 @@ class PrepaidBalanceReportsDownloadFunctionalTest extends MonetizationFunctional
 
     $filename = "prepaid-balance-report-{$year}-{$month_numeric}.csv";
     $this->assertStatusCodeEquals(Response::HTTP_OK);
-    $this->assertHeaderEquals('text/csv; charset=UTF-8', $this->drupalGetHeader('Content-Type'));
-    $this->assertHeaderEquals("attachment; filename=$filename", $this->drupalGetHeader('Content-Disposition'));
+    $this->assertHeaderEquals('text/csv; charset=UTF-8', $this->getSession()->getResponseHeader('Content-Type'));
+    $this->assertHeaderEquals("attachment; filename=$filename", $this->getSession()->getResponseHeader('Content-Disposition'));
   }
 
 }

--- a/tests/src/Traits/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeMonetizationTestTrait.php
@@ -134,7 +134,7 @@ trait ApigeeMonetizationTestTrait {
       'first_name' => $this->randomMachineName(),
       'last_name' => $this->randomMachineName(),
       'name' => $this->randomMachineName(),
-      'pass' => \user_password(),
+      'pass' => \Drupal::service('password_generator')->generate(),
       'status' => $status,
     ];
     if ($rid) {

--- a/tests/src/Traits/ApigeeX/ApigeeMonetizationTestTrait.php
+++ b/tests/src/Traits/ApigeeX/ApigeeMonetizationTestTrait.php
@@ -132,7 +132,7 @@ trait ApigeeMonetizationTestTrait {
       'first_name' => $this->randomMachineName(),
       'last_name' => $this->randomMachineName(),
       'name' => strtolower($this->randomMachineName()),
-      'pass' => \user_password(),
+      'pass' => \Drupal::service('password_generator')->generate(),
       'status' => $status,
     ];
     if ($rid) {


### PR DESCRIPTION
Closes #367 

Bump Drupal core version requirement to 9.2.13 and removed support for Drupal 8.
Also fixed deprecated methods which are removed from Drupal 10.0.0

See : https://www.drupal.org/sa-core-2022-003
Fix `Incorrect authorization in Drupal core` and `Improper input validation in Drupal core`