### PR TITLE
Fix for Support for keys without a placeholder prefix is deprecated in Drupal 9.1.0

### DIFF
--- a/modules/apigee_m10n_add_credit/src/AddCreditService.php
+++ b/modules/apigee_m10n_add_credit/src/AddCreditService.php
@@ -108,14 +108,14 @@ class AddCreditService implements AddCreditServiceInterface {
       case 'balance_adjustment_report':
         $options = ['langcode' => $message['langcode']];
         $message['subject'] = $this->t('Add Credit successfully applied to account (@email@team_name) from @site', $params, $options);
-        $message['body'][0] = $this->t($params['report_text'], $params, $options);
+        $message['body'][0] = $this->t($params['@report_text'], $params, $options);
         break;
 
       case 'balance_adjustment_error_report':
         $options = ['langcode' => $message['langcode']];
         $params['@site'] = $this->config->get('system.site')->get('name');
         $message['subject'] = $this->t('Developer account add credit error from @site', $params, $options);
-        $body = "There was an error applying a credit to an account. \n\r\n\r" . $params['report_text'] . "\n\r\n\r@error";
+        $body = "There was an error applying a credit to an account. \n\r\n\r" . $params['@report_text'] . "\n\r\n\r@error";
         $message['body'][0] = $this->t($body, $params, $options);
         break;
 

--- a/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJob.php
+++ b/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJob.php
@@ -212,7 +212,7 @@ class BalanceAdjustmentJob extends EdgeJob {
       // Re-add empty values to message context.
       $message_context = $message_context + $all_placeholders;
       // Add the report text to the message context.
-      $message_context['report_text'] = $report_text;
+      $message_context['@report_text'] = $report_text;
 
       // If there were any errors or exceptions, they still need to be thrown.
       if (isset($thrown)) {

--- a/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJobX.php
+++ b/modules/apigee_m10n_add_credit/src/Job/BalanceAdjustmentJobX.php
@@ -196,7 +196,7 @@ class BalanceAdjustmentJobX extends EdgeJob {
       // Re-add empty values to message context.
       $message_context = $message_context + $all_placeholders;
       // Add the report text to the message context.
-      $message_context['report_text'] = $report_text;
+      $message_context['@report_text'] = $report_text;
 
       // If there were any errors or exceptions, they still need to be thrown.
       if (isset($thrown)) {


### PR DESCRIPTION
Fixes #399 