### PR TITLE
Fix for dev dependencies error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "behat/mink-extension": "^2.0",
         "bex/behat-screenshot": "^1.2",
         "drupal/core-dev": "^9.3",
-        "drupal/drupal-extension": "master-dev",
         "drush/drush": "^9.0 || ^10.0",
         "mglaman/drupal-check": "^1.3",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Fixes #405 
"drupal/drupal-extension" was added when moving from travis to circle ci .
As currently we are using Github action we don't need this library and can be safely removed.
This issue is similar to https://github.com/apigee/apigee-edge-drupal/issues/757