### PR TITLE
Set default cache value if cache returns NULL while running test case

### DIFF
--- a/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsTest.php
+++ b/modules/apigee_m10n_teams/tests/src/Kernel/MonetizationTeamsTest.php
@@ -101,6 +101,14 @@ class MonetizationTeamsTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    // Setting teams cache to 900 to make sure null value is not returned in getCacheMaxAge().
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('apigee_edge_teams.team_settings');
+
+    if (NULL === $config->get('cache_expiration')) {
+      $config->set('cache_expiration', 900);
+      $config->save(TRUE);
+    }
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $this->entity_type_manager = $this->container->get('entity_type.manager');
 


### PR DESCRIPTION
In Drupal 10.1, fixed test-case failing, due to  error `TypeError: Drupal\apigee_edge_teams\Entity\Team::getCacheMaxAge(): Return value must be of type int, null returned`.
Set default cache value if cache returns NULL while running test case
Originally issue PR https://github.com/apigee/apigee-edge-drupal/pull/917