### PR TITLE
Removed Drupal 9.4 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,6 @@ jobs:
           - "8.2"
         drupal-core:
           # Should update the following as the minimum supported version from Drupal.org
-          - "9.4.x"
           - "9.5.x"
           - "10.0.x"
           - "10.1.x"
@@ -45,8 +44,6 @@ jobs:
           - "Edge"
           - "X"
         exclude:
-          - php-version: "8.2"
-            drupal-core: "9.4.x"
           - php-version: "8.2"
             drupal-core: "9.5.x"
           - php-version: "8.0"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "~1.0 || ^2.0",
         "drupal/apigee_edge": "^2.0.2 || ^3.0.0",
-        "drupal/core": "^9.4 || ^10.0",
+        "drupal/core": "^9.5 || ^10.0",
         "drupal/requirement": "^1.2",
         "drupal/jquery_ui_dialog": "^2.0",
         "apigee/apigee-client-php": "^2.0.16 || ^3.0.0"
@@ -17,7 +17,7 @@
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.1.1",
         "drupal/drupal-extension": "^4.2.1 || ~5",
-        "drupal/core-dev": "^9.4 || ^10.0",
+        "drupal/core-dev": "^9.5 || ^10.0",
         "drush/drush": "^11.5",
         "mglaman/drupal-check": "^1.3",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Closes #450  
Drupal 9.4 EOL 2023-06-21,
Removed support for Drupal 9.4.