### PR TITLE
Fix for deprecation: Implicit conversion from float to int loses precision

### DIFF
--- a/tests/src/Functional/ApigeeX/PurchasedProductListTest.php
+++ b/tests/src/Functional/ApigeeX/PurchasedProductListTest.php
@@ -90,7 +90,7 @@ class PurchasedProductListTest extends MonetizationFunctionalTestBase {
 
     $default_timezone = new \DateTimeZone('UTC');
     $datetimeImmutable = new \DateTimeImmutable();
-    $start_time = $datetimeImmutable->setTimezone($default_timezone)->setTimestamp($purchased_product->getStartTime() / 1000)->format('m/d/Y');
+    $start_time = $datetimeImmutable->setTimezone($default_timezone)->setTimestamp((int) ($purchased_product->getStartTime() / 1000))->format('m/d/Y');
 
     // Checking my purchased plans table columns.
     $this->assertCssElementText('.purchased-plan-row:nth-child(1) td.purchased-plan-status', 'Active');


### PR DESCRIPTION
Closes #454 