### PR TITLE
Fix for deprecation notice : ucfirst(): Passing null to parameter #1 ($string) of type string

### DIFF
--- a/tests/src/Traits/RatePlanDetailsKernelTestAssertionTrait.php
+++ b/tests/src/Traits/RatePlanDetailsKernelTestAssertionTrait.php
@@ -56,7 +56,7 @@ trait RatePlanDetailsKernelTestAssertionTrait {
     $this->assertCssElementText(".rate-plan-detail .rate-plan-detail__overview__country > .field__item", $details->getOrganization()->getCountry());
     // Pricing Type.
     $this->assertCssElementText(".rate-plan-detail .rate-plan-detail__overview__pricing-type > .field__label", 'Pricing type');
-    $this->assertCssElementText(".rate-plan-detail .rate-plan-detail__overview__pricing-type > .field__item", ucfirst($details->getRevenueType()));
+    $this->assertCssElementText(".rate-plan-detail .rate-plan-detail__overview__pricing-type > .field__item", ucfirst($details->getRevenueType() ? $details->getRevenueType() : ''));
 
     // Test rate plan rates.
     $prefix = '.rate-plan-detail:first-child';


### PR DESCRIPTION
Closes #457 