### PR TITLE
Fx for deprecation Calling InfoParserDynamic::__construct() without the $app_root argument is deprecated in drupal:10.1.0

### DIFF
--- a/apigee_m10n.module
+++ b/apigee_m10n.module
@@ -135,15 +135,16 @@ function apigee_m10n_form_user_admin_permissions_alter(&$form, FormStateInterfac
  * Implements hook_apigee_edge_user_agent_string_alter().
  */
 function apigee_m10n_apigee_edge_user_agent_string_alter(&$user_agent_parts) {
-    $infoParser = new InfoParser();
-    $m10_module_info = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_m10n')->getPathname());
+  $app_root = \Drupal::hasService('kernel') ? \Drupal::root() : DRUPAL_ROOT;
+  $infoParser = new InfoParser($app_root);
+  $m10_module_info = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_m10n')->getPathname());
   
-    if (!isset($m10_module_info['version'])) {
-      $m10_module_info['version'] = '2.x-dev';
-    }
+  if (!isset($m10_module_info['version'])) {
+    $m10_module_info['version'] = '2.x-dev';
+  }
 
-    // m10 module info at beginning of the array.
-    array_unshift($user_agent_parts , $m10_module_info['name'] . '/' . $m10_module_info['version']);
+  // m10 module info at beginning of the array.
+  array_unshift($user_agent_parts , $m10_module_info['name'] . '/' . $m10_module_info['version']);
 }
 
 /**


### PR DESCRIPTION
Closes #459