### PR TITLE
Minimum version bump of Drupal to 10.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cweagans/composer-patches": "~1.6",
         "commerceguys/intl": "^2.0",
         "drupal/apigee_edge": "^3.0.0",
-        "drupal/core": "^10.1",
+        "drupal/core": "^10.2",
         "drupal/requirement": "^1.2",
         "drupal/jquery_ui_dialog": "^2.0",
         "apigee/apigee-client-php": "^3.0.0"
@@ -17,7 +17,7 @@
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.1.1",
         "drupal/drupal-extension": "~5",
-        "drupal/core-dev": "^10.1",
+        "drupal/core-dev": "^10.2",
         "drush/drush": "^12.4.3",
         "mglaman/drupal-check": "^1.3",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Minimum version bump of Drupal to 10.2 
Fixes #476 