### PR TITLE
Fix for Drupal.Commenting.DocComment.ShortSingleLine

### DIFF
--- a/src/Controller/PrepaidBalanceControllerInterface.php
+++ b/src/Controller/PrepaidBalanceControllerInterface.php
@@ -31,8 +31,11 @@ use Drupal\Core\Entity\EntityInterface;
 interface PrepaidBalanceControllerInterface {
 
   /**
-   * Cache prefix is new 'reserved' cache tag format CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:$suffix,
-   * if something is tagged with this, it will be a cache miss on POST requests.
+   * Cache prefix is new 'reserved' cache tag format.
+   *
+   * CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:$suffix.
+   *
+   * If tagged, it will be a cache miss on POST.
    */
   const CACHE_MISS = 'CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form';
 

--- a/src/Controller/PrepaidBalanceXControllerInterface.php
+++ b/src/Controller/PrepaidBalanceXControllerInterface.php
@@ -31,8 +31,11 @@ use Drupal\Core\Entity\EntityInterface;
 interface PrepaidBalanceXControllerInterface {
 
   /**
-   * Cache prefix is new 'reserved' cache tag format CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:$suffix,
-   * if something is tagged with this, it will be a cache miss on POST requests.
+   * Cache prefix is new 'reserved' cache tag format.
+   *
+   * CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:$suffix.
+   *
+   * If tagged, it will be a cache miss on POST.
    */
   const CACHE_MISS = 'CACHE_MISS_IF_UNCACHEABLE_HTTP_METHOD:form';
 


### PR DESCRIPTION
Fixes Doc comment short description must be on a single line, further text should be a separate paragraph (Drupal.Commenting.DocComment.ShortSingleLine)