### PR TITLE
Updated watchdog_exception() to Error::logException() for Drupal 11 compatibility

### DIFF
--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
@@ -26,6 +26,7 @@ use CommerceGuys\Intl\Currency\CurrencyRepository;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\apigee_m10n\ApigeeEdgeSdkConnectorTrait;
 use Drupal\apigee_m10n_add_credit\AddCreditConfig;
 use Drupal\commerce_price\Price;

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
@@ -125,7 +125,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
       });
     }
     catch (\Exception $exception) {
-      watchdog_exception('apigee_kickstart', $exception);
+      Error::logException('apigee_kickstart', $exception);
     }
   }
 
@@ -238,7 +238,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
           ->save();
       }
       catch (\Exception $exception) {
-        watchdog_exception('apigee_kickstart', $exception);
+        Error::logException('apigee_kickstart', $exception);
       }
     }
   }

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
@@ -106,6 +106,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
     $this->languageManager = $language_manager;
     $this->currencyRepository = new CurrencyRepository();
     $this->importableCurrencies = $this->getImportableCurrencies();
+    $logger = \Drupal::logger('apigee_kickstart');
 
     // Get organization supported currencies.
     try {
@@ -126,7 +127,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
       });
     }
     catch (\Exception $exception) {
-      Error::logException('apigee_kickstart', $exception);
+      Error::logException($logger, $exception);
     }
   }
 
@@ -189,6 +190,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $currencies = $form_state->getValue('supported_currencies');
     $store = $form_state->getValue('store');
+    $logger = \Drupal::logger('apigee_kickstart');
 
     /** @var \Apigee\Edge\Api\Monetization\Entity\SupportedCurrencyInterface $currency */
     foreach ($currencies as $currency_code) {
@@ -239,7 +241,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
           ->save();
       }
       catch (\Exception $exception) {
-        Error::logException('apigee_kickstart', $exception);
+        Error::logException($logger, $exception);
       }
     }
   }

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/AddCreditProducts.php
@@ -106,7 +106,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
     $this->languageManager = $language_manager;
     $this->currencyRepository = new CurrencyRepository();
     $this->importableCurrencies = $this->getImportableCurrencies();
-    $logger = \Drupal::logger('apigee_kickstart');
+    $logger = \Drupal::logger('apigee_m10n_add_credit');
 
     // Get organization supported currencies.
     try {
@@ -190,7 +190,7 @@ class AddCreditProducts extends RequirementBase implements ContainerFactoryPlugi
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $currencies = $form_state->getValue('supported_currencies');
     $store = $form_state->getValue('store');
-    $logger = \Drupal::logger('apigee_kickstart');
+    $logger = \Drupal::logger('apigee_m10n_add_credit');
 
     /** @var \Apigee\Edge\Api\Monetization\Entity\SupportedCurrencyInterface $currency */
     foreach ($currencies as $currency_code) {

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/CommerceStore.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/CommerceStore.php
@@ -25,6 +25,7 @@ use CommerceGuys\Addressing\AddressFormat\AddressField;
 use CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\address\FieldHelper;
 use Drupal\address\LabelHelper;
 use Drupal\apigee_edge\SDKConnectorInterface;
@@ -100,7 +101,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
       }
     }
     catch (\Exception $exception) {
-      watchdog_exception('apigee_m10n_add_credit', $exception);
+      Error::logException('apigee_m10n_add_credit', $exception);
     }
   }
 
@@ -234,7 +235,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
       $store->save();
     }
     catch (\Exception $exception) {
-      watchdog_exception('apigee_m10n_add_credit', $exception);
+      Error::logException('apigee_m10n_add_credit', $exception);
     }
   }
 

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/CommerceStore.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/CommerceStore.php
@@ -85,6 +85,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->sdkConnector = $sdk_connector;
     $this->subdivisionRepository = $subdivision_repository;
+    $logger = \Drupal::logger('apigee_m10n_add_credit');
 
     try {
       $organization_id = $this->sdkConnector->getOrganization();
@@ -101,7 +102,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
       }
     }
     catch (\Exception $exception) {
-      Error::logException('apigee_m10n_add_credit', $exception);
+      Error::logException($logger, $exception);
     }
   }
 
@@ -227,6 +228,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $form_state->cleanValues();
+    $logger = \Drupal::logger('apigee_m10n_add_credit');
 
     try {
       $values = $form_state->getValues();
@@ -235,7 +237,7 @@ class CommerceStore extends RequirementBase implements ContainerFactoryPluginInt
       $store->save();
     }
     catch (\Exception $exception) {
-      Error::logException('apigee_m10n_add_credit', $exception);
+      Error::logException($logger, $exception);
     }
   }
 

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/PaymentGateway.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/PaymentGateway.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_m10n_add_credit\Plugin\Requirement\Requirement;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Utility\Error;
 use Drupal\commerce_payment\PaymentGatewayManager;
 use Drupal\requirement\Plugin\RequirementBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -131,7 +132,7 @@ class PaymentGateway extends RequirementBase implements ContainerFactoryPluginIn
       $gateway->save();
     }
     catch (\Exception $exception) {
-      watchdog_exception('apigee_m10n_add_credit', $exception);
+      Error::logException('apigee_m10n_add_credit', $exception);
     }
   }
 

--- a/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/PaymentGateway.php
+++ b/modules/apigee_m10n_add_credit/src/Plugin/Requirement/Requirement/PaymentGateway.php
@@ -124,6 +124,7 @@ class PaymentGateway extends RequirementBase implements ContainerFactoryPluginIn
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $form_state->cleanValues();
+    $logger = \Drupal::logger('apigee_m10n_add_credit');
 
     try {
       $gateway = $this->getEntityTypeManager()
@@ -132,7 +133,7 @@ class PaymentGateway extends RequirementBase implements ContainerFactoryPluginIn
       $gateway->save();
     }
     catch (\Exception $exception) {
-      Error::logException('apigee_m10n_add_credit', $exception);
+      Error::logException($logger, $exception);
     }
   }
 

--- a/src/Entity/Storage/RatePlanStorage.php
+++ b/src/Entity/Storage/RatePlanStorage.php
@@ -24,6 +24,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\apigee_edge\Entity\Controller\EdgeEntityControllerInterface;
 use Drupal\apigee_edge\Entity\Storage\EdgeEntityStorageBase;
 use Drupal\apigee_m10n\Entity\RatePlanInterface;
@@ -113,7 +114,7 @@ class RatePlanStorage extends EdgeEntityStorageBase implements RatePlanStorageIn
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          watchdog_exception('apigee_m10n', $exception);
+          Error::logException('apigee_m10n', $exception);
         }
       }
       $this->invokeStorageLoadHook($entities);

--- a/src/Entity/Storage/RatePlanStorage.php
+++ b/src/Entity/Storage/RatePlanStorage.php
@@ -103,6 +103,7 @@ class RatePlanStorage extends EdgeEntityStorageBase implements RatePlanStorageIn
     $this->withController(function (RatePlanSdkControllerProxyInterface $controller) use ($product_bundle_id, $include_future_plans, &$entities) {
       // Load the  rate plans for this product bundle.
       $sdk_entities = $controller->loadRatePlansByProductBundle($product_bundle_id, $include_future_plans);
+      $logger = \Drupal::logger('apigee_m10n');
       // Convert the SDK entities to drupal entities.
       /** @var \Apigee\Edge\Api\Monetization\Entity\RatePlanInterface $entity */
       foreach ($sdk_entities as $id => $entity) {
@@ -114,7 +115,7 @@ class RatePlanStorage extends EdgeEntityStorageBase implements RatePlanStorageIn
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          Error::logException('apigee_m10n', $exception);
+          Error::logException($logger, $exception);
         }
       }
       $this->invokeStorageLoadHook($entities);

--- a/src/Entity/Storage/XRatePlanStorage.php
+++ b/src/Entity/Storage/XRatePlanStorage.php
@@ -24,6 +24,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\apigee_edge\Entity\Controller\EdgeEntityControllerInterface;
 use Drupal\apigee_edge\Entity\Storage\EdgeEntityStorageBase;
 use Drupal\apigee_m10n\Entity\Storage\Controller\XRatePlanSdkControllerProxyInterface;
@@ -113,7 +114,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          watchdog_exception('apigee_m10n', $exception);
+          Error::logException('apigee_m10n', $exception);
         }
       }
       $this->invokeStorageLoadHook($entities);
@@ -224,7 +225,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          watchdog_exception('apigee_m10n', $exception);
+          Error::logException('apigee_m10n', $exception);
           $this->cacheBackend->delete($cid);
         }
       }

--- a/src/Entity/Storage/XRatePlanStorage.php
+++ b/src/Entity/Storage/XRatePlanStorage.php
@@ -103,6 +103,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
     $this->withController(function (XRatePlanSdkControllerProxyInterface $controller) use ($product_bundle_id, $include_future_plans, &$entities) {
       // Load the  rate plans for this xproduct.
       $sdk_entities = $controller->loadRatePlansByProduct($product_bundle_id, $include_future_plans);
+      $logger = \Drupal::logger('apigee_m10n');
       // Convert the SDK entities to drupal entities.
       /** @var \Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface $entity */
       foreach ($sdk_entities as $id => $entity) {
@@ -114,7 +115,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          Error::logException('apigee_m10n', $exception);
+          Error::logException($logger, $exception);
         }
       }
       $this->invokeStorageLoadHook($entities);
@@ -209,6 +210,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
   public function loadAll(): array {
     $cid = 'values:xrateplan';
     $rate_plans = $this->cacheBackend->get($cid);
+    $logger = \Drupal::logger('apigee_m10n');
     if ($rate_plans && $rate_plans->data) {
       return $rate_plans->data;
     }
@@ -225,7 +227,7 @@ class XRatePlanStorage extends EdgeEntityStorageBase implements XRatePlanStorage
           }
         }
         catch (InvalidRatePlanIdException $exception) {
-          Error::logException('apigee_m10n', $exception);
+          Error::logException($logger, $exception);
           $this->cacheBackend->delete($cid);
         }
       }

--- a/src/Entity/XRatePlan.php
+++ b/src/Entity/XRatePlan.php
@@ -31,6 +31,7 @@ use Apigee\Edge\Api\Monetization\Entity\DeveloperRatePlanInterface;
 use Apigee\Edge\Entity\EntityInterface as EdgeEntityInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\apigee_edge\Entity\FieldableEdgeEntityBase;
 use Drupal\apigee_m10n\Entity\Property\ApiXProductPropertyAwareDecoratorTrait;
 use Drupal\apigee_m10n\Entity\Property\BillingPeriodPropertyAwareDecoratorTrait;
@@ -235,7 +236,7 @@ class XRatePlan extends FieldableEdgeEntityBase implements XRatePlanInterface {
         }
       }
       catch (InvalidRatePlanIdException $exception) {
-        watchdog_exception('apigee_m10n', $exception);
+        Error::logException('apigee_m10n', $exception);
       }
     }
 

--- a/src/Entity/XRatePlan.php
+++ b/src/Entity/XRatePlan.php
@@ -224,6 +224,7 @@ class XRatePlan extends FieldableEdgeEntityBase implements XRatePlanInterface {
     $utc = new \DateTimeZone('UTC');
     $currentTimestamp = (new \DateTimeImmutable())->setTimezone($utc);
     $currentTimestamp = (int) ($currentTimestamp->getTimestamp() . $currentTimestamp->format('v'));
+    $logger = \Drupal::logger('apigee_m10n');
 
     /** @var \Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface $entity */
     foreach ($rateplans as $id => $entity) {
@@ -236,7 +237,7 @@ class XRatePlan extends FieldableEdgeEntityBase implements XRatePlanInterface {
         }
       }
       catch (InvalidRatePlanIdException $exception) {
-        Error::logException('apigee_m10n', $exception);
+        Error::logException($logger, $exception);
       }
     }
 

--- a/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
+++ b/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\apigee_m10n\Plugin\Requirement\Requirement;
 
+use Drupal\Core\Utility\Error;
 use Drupal\apigee_m10n\ApigeeEdgeSdkConnectorTrait;
 use Drupal\requirement\Plugin\RequirementBase;
 
@@ -57,7 +58,7 @@ class ApigeeEdgeConnection extends RequirementBase {
       return TRUE;
     }
     catch (\Exception $exception) {
-      watchdog_exception('requirement', $exception);
+      Error::logException('requirement', $exception);
     }
 
     return FALSE;

--- a/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
+++ b/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
@@ -53,12 +53,13 @@ class ApigeeEdgeConnection extends RequirementBase {
    * {@inheritdoc}
    */
   public function isCompleted(): bool {
+    $logger = \Drupal::logger('requirement');
     try {
       $this->getApigeeEdgeSdkConnector()->testConnection();
       return TRUE;
     }
     catch (\Exception $exception) {
-      Error::logException('requirement', $exception);
+      Error::logException($logger, $exception);
     }
 
     return FALSE;

--- a/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
+++ b/src/Plugin/Requirement/Requirement/ApigeeEdgeConnection.php
@@ -53,7 +53,7 @@ class ApigeeEdgeConnection extends RequirementBase {
    * {@inheritdoc}
    */
   public function isCompleted(): bool {
-    $logger = \Drupal::logger('requirement');
+    $logger = \Drupal::logger('apigee_m10n');
     try {
       $this->getApigeeEdgeSdkConnector()->testConnection();
       return TRUE;


### PR DESCRIPTION
Fixes #509 & #455
watchdog_exception() is deprecated in drupal:10.1.0 and is removed from drupal:11.0.0. Use \Drupal\Core\Utility\Error::logException() instead.
https://www.drupal.org/node/2932520