### PR TITLE
Fix added for replacement of Datetime::formatExample()

### DIFF
--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -38,11 +38,12 @@ use Drupal\Core\Form\FormStateInterface;
 class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
-   * Example format used as Datetime::formatExample is removed from D11.
+   * Example format used as Datetime::formatExample is deprecated 
+   * in Drupal:10.2.0 and is removed from Drupal:11.0.0.
    *
    * @var string
    */
-  public const DATESTAMPFORMAT = 'YYYY-MM-DD hh:mm:ss';
+  public const DATESTAMPFORMAT = 'YYYY-MM-DD HH:MM:SS';
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -20,8 +20,6 @@
 namespace Drupal\apigee_m10n\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Datetime\Element\Datetime;
-use Drupal\Core\Datetime\Entity\DateFormat;
 use Drupal\Core\Datetime\Plugin\Field\FieldWidget\TimestampDatetimeWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -40,11 +38,16 @@ use Drupal\Core\Form\FormStateInterface;
 class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
+   * Example format used as Datetime::formatExample is removed from D11.
+   *
+   * @var string
+   */
+  public const DATESTAMPFORMAT = 'YYYY-MM-DD hh:mm:ss';
+
+  /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $date_format = DateFormat::load('html_date')->getPattern();
-    $time_format = DateFormat::load('html_time')->getPattern();
     $default_value = isset($items[$delta]->value) ? DrupalDateTime::createFromTimestamp($items[$delta]->value->getTimestamp()) : '';
     $element['value'] = $element + [
       '#type'              => 'datetime',
@@ -53,7 +56,7 @@ class DatestampWidget extends TimestampDatetimeWidget {
       '#date_time_element' => 'none',
       '#date_year_range'   => '1902:2037',
     ];
-    $element['value']['#description'] = $this->t('Format: %format. Leave blank to use the time of form submission.', ['%format' => Datetime::formatExample($date_format . ' ' . $time_format)]);
+    $element['value']['#description'] = $this->t('Format: %format. Leave blank to use the time of form submission.', ['%format' => static::DATESTAMPFORMAT]);
 
     return $element;
   }

--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -38,6 +38,8 @@ use Drupal\Core\Form\FormStateInterface;
 class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
+   * Constant fot Date Time format.
+   *
    * @var string
    */
   public const DATESTAMPFORMAT = 'YYYY-MM-DD HH:MM:SS';

--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -38,8 +38,6 @@ use Drupal\Core\Form\FormStateInterface;
 class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
-   * Example format used as Datetime::formatExample is deprecated in Drupal:10.2.0 and is removed from Drupal:11.0.0.
-   *
    * @var string
    */
   public const DATESTAMPFORMAT = 'YYYY-MM-DD HH:MM:SS';

--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -38,9 +38,8 @@ use Drupal\Core\Form\FormStateInterface;
 class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
-   * Example format used as Datetime::formatExample is deprecated 
-   * in Drupal:10.2.0 and is removed from Drupal:11.0.0.
-   *
+   * Example format used as Datetime::formatExample is deprecated in Drupal:10.2.0 and is removed from Drupal:11.0.0.
+   * 
    * @var string
    */
   public const DATESTAMPFORMAT = 'YYYY-MM-DD HH:MM:SS';

--- a/src/Plugin/Field/FieldWidget/DatestampWidget.php
+++ b/src/Plugin/Field/FieldWidget/DatestampWidget.php
@@ -39,7 +39,7 @@ class DatestampWidget extends TimestampDatetimeWidget {
 
   /**
    * Example format used as Datetime::formatExample is deprecated in Drupal:10.2.0 and is removed from Drupal:11.0.0.
-   * 
+   *
    * @var string
    */
   public const DATESTAMPFORMAT = 'YYYY-MM-DD HH:MM:SS';


### PR DESCRIPTION
Fixes #512 

@deprecated in drupal:10.2.0 and is removed from drupal:11.0.0. 
HTML date input format should not be exposed to users, as browser widgets expose input differently, varying by vendor, locale, device type, etc.
https://www.drupal.org/project/drupal/issues/2791693