### PR TITLE
Fix issue-creation of dynamic property Drupal\apigee_m10n\Entity\PurchasedPlan::$original is deprecated

### DIFF
--- a/config/install/core.entity_view_display.rate_plan.rate_plan.teaser.yml
+++ b/config/install/core.entity_view_display.rate_plan.rate_plan.teaser.yml
@@ -18,14 +18,6 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-  purchase:
-    type: apigee_purchase_plan_link
-    weight: 1
-    region: content
-    label: visually_hidden
-    settings:
-      label: 'Purchase Plan'
-    third_party_settings: {  }
 hidden:
   advance: true
   contractDuration: true

--- a/config/install/core.entity_view_display.rate_plan.rate_plan.teaser.yml
+++ b/config/install/core.entity_view_display.rate_plan.rate_plan.teaser.yml
@@ -18,6 +18,14 @@ content:
     settings:
       link: false
     third_party_settings: {  }
+  purchase:
+    type: apigee_purchase_plan_link
+    weight: 1
+    region: content
+    label: visually_hidden
+    settings:
+      label: 'Purchase Plan'
+    third_party_settings: {  }
 hidden:
   advance: true
   contractDuration: true

--- a/src/Entity/PurchasedPlan.php
+++ b/src/Entity/PurchasedPlan.php
@@ -67,6 +67,7 @@ use Drupal\user\UserInterface;
  *   field_ui_base_route    = "apigee_m10n.settings.purchased_plan",
  * )
  */
+#[\AllowDynamicProperties]
 class PurchasedPlan extends FieldableEdgeEntityBase implements PurchasedPlanInterface, EntityOwnerInterface {
 
   use EndDatePropertyAwareDecoratorTrait {


### PR DESCRIPTION
Fixes 

- Deprecated function: Creation of dynamic property Drupal\apigee_m10n\Entity\PurchasedPlan::$original is deprecated in Drupal\Core\Entity\EntityStorageBase->doPreSave() (line 524 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).