### PR TITLE
Add Buy Api tab in Teams and displaying catalog items for AppGroups

### DIFF
--- a/modules/apigee_m10n_teams/apigee_m10n_teams.links.task.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.links.task.yml
@@ -32,8 +32,15 @@ apigee_m10n_teams.team_reports:
   weight: 10
 
 apigee_m10n_teams.team_plans:
+  class: Drupal\apigee_m10n_teams\Plugin\Menu\LocalTask\TeamPlansLocalTask
   route_name: apigee_monetization.team_plans
-  title: 'Pricing and Plans'
+  base_route: entity.team.canonical
+  parent_id: apigee_m10n_teams.balance_and_plans
+  weight: 1
+
+apigee_m10n_teams.team_xplans:
+  class: Drupal\apigee_m10n_teams\Plugin\Menu\LocalTask\TeamPlansLocalTask
+  route_name: apigee_monetization.team_xplans
   base_route: entity.team.canonical
   parent_id: apigee_m10n_teams.balance_and_plans
   weight: 1

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.module
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.module
@@ -47,6 +47,25 @@ function apigee_m10n_teams_field_widget_info_alter(array &$info) {
 }
 
 /**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function apigee_m10n_teams_menu_local_tasks_alter(array &$local_tasks) {
+  $monetization = \Drupal::service('apigee_m10n.monetization');
+  if (isset($local_tasks['tabs']) && is_array($local_tasks['tabs'])) {
+    foreach ($local_tasks['tabs'] as &$tab_group) {
+      if (is_array($tab_group)) {
+        if ($monetization->isOrganizationApigeeXorHybrid()) {
+          unset($tab_group['apigee_m10n_teams.team_plans']);
+        }
+        else {
+          unset($tab_group['apigee_m10n_teams.team_xplans']);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_access().
  */
 function apigee_m10n_teams_purchased_plan_access(EntityInterface $entity, $operation, AccountInterface $account) {

--- a/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
+++ b/modules/apigee_m10n_teams/apigee_m10n_teams.routing.yml
@@ -57,6 +57,17 @@ apigee_monetization.team_plans:
     _apigee_monetization_route: TRUE
     _apigee_developer_route: apigee_monetization.plans
 
+apigee_monetization.team_xplans:
+  path: /teams/{team}/xplans
+  defaults:
+    _controller: \Drupal\apigee_m10n_teams\Controller\TeamBuyApiController::teamCatalogPage
+    _title: "Buy APIs"
+  requirements:
+    _team_permission: 'view rate_plan'
+  options:
+    _apigee_monetization_route: TRUE
+    _apigee_developer_route: apigee_monetization.plans
+
 apigee_m10n_teams.team_billing_details:
   path: '/teams/{team}/monetization/billing-details'
   defaults:

--- a/modules/apigee_m10n_teams/src/Controller/TeamBuyApiController.php
+++ b/modules/apigee_m10n_teams/src/Controller/TeamBuyApiController.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Controller;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_m10n\Controller\BuyApiController;
+use Drupal\apigee_m10n\Entity\XRatePlan;
+
+/**
+ * Generates the buy apis page.
+ */
+class TeamBuyApiController extends BuyApiController {
+
+  /**
+   * Gets a list of available plans for this user.
+   *
+   * @param \Drupal\apigee_edge_teams\Entity\TeamInterface $team
+   *   The drupal user/developer.
+   *
+   * @return array
+   *   The plans render array.
+   */
+  public function teamCatalogPage(TeamInterface $team) {
+    $rate_plans = [];
+    // Get the active rate plans of the organization.
+    $all_ratePlans = XRatePlan::loadAll();
+
+    foreach ($all_ratePlans as $rate_plan) {
+      $rate_plans["{$rate_plan->id()}"] = $rate_plan;
+    }
+    return $this->buildPage($rate_plans);
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/Entity/Access/TeamXRatePlanAccessControlHandler.php
+++ b/modules/apigee_m10n_teams/src/Entity/Access/TeamXRatePlanAccessControlHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Entity\Access;
+
+use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\apigee_m10n\Entity\Access\XRatePlanAccessControlHandler;
+use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface;
+use Drupal\apigee_m10n_teams\MonetizationTeamsInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access controller for the rate_plan entity.
+ */
+class TeamXRatePlanAccessControlHandler extends XRatePlanAccessControlHandler {
+
+
+  /**
+   * The teams monetization service.
+   *
+   * @var \Drupal\apigee_m10n_teams\MonetizationTeamsInterface
+   */
+  protected $teamMonitization;
+
+  /**
+   * The team access service.
+   *
+   * @var \Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface
+   */
+  protected $teamAccess;
+
+  /**
+   * Constructs an access control handler instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\apigee_m10n_teams\MonetizationTeamsInterface $team_monetization
+   *   Teams monetization factory.
+   * @param \Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface $team_access
+   *   The team access service.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entityTypeManager, MonetizationTeamsInterface $team_monetization, TeamPermissionAccessInterface $team_access) {
+    parent::__construct($entity_type, $entityTypeManager);
+    $this->teamMonitization = $team_monetization;
+    $this->teamAccess = $team_access;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager'),
+      $container->get('apigee_m10n.teams'),
+      $container->get('apigee_m10n_teams.access_check.team_permission')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    // Get the SDK rate plan.
+    /** @var \Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface $sdk_rate_plan */
+    $sdk_rate_plan = $entity->decorated();
+
+    if ($sdk_rate_plan instanceof StandardRatePlanInterface && $this->teamMonitization->currentTeam()) {
+      return $this->teamMonitization->entityAccess($entity, $operation, $account);
+    }
+
+    return parent::checkAccess($entity, $operation, $account);
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/Entity/TeamsXRatePlan.php
+++ b/modules/apigee_m10n_teams/src/Entity/TeamsXRatePlan.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_m10n_teams\Entity;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\apigee_m10n\Entity\XRatePlan;
+use Drupal\apigee_m10n_teams\Entity\Traits\TeamRouteAwarePropertyTrait;
+
+/**
+ * Overridden team aware class for the AppGroups`rate_plan` entity.
+ */
+#[\AllowDynamicProperties]
+class TeamsXRatePlan extends XRatePlan {
+
+  use TeamRouteAwarePropertyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function toUrl($rel = 'canonical', array $options = []) {
+    // The string formatter assumes entities are revisionable.
+    $rel = ($rel === 'revision') ? 'canonical' : $rel;
+
+    // Check for team context.
+    $rel = (($team_id = $this->getTeamId()) && $rel === 'canonical') ? 'team' : $rel;
+    $rel = (($team_id = $this->getTeamId()) && $rel === 'purchase') ? 'team-purchase' : $rel;
+
+    $url = parent::toUrl($rel, $options);
+
+    // Add the team if this is a team URL.
+    if (in_array($rel, ['team', 'team-purchase']) && !empty($team_id)) {
+      // Removes the user route parameter.
+      $url->setRouteParameters(array_diff_key($url->getRouteParameters(), ['user' => NULL]));
+      $url->setRouteParameter('team', $team_id);
+    }
+
+    return $url;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPurchase():? array {
+    // Return a team array if this is a team route.
+    return (($team = $this->getTeam()) && $team instanceof TeamInterface)
+      ? ['team' => $team]
+      : parent::getPurchase();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return array_merge(['url.team'], parent::getCacheContexts());
+  }
+
+}

--- a/modules/apigee_m10n_teams/src/MonetizationTeams.php
+++ b/modules/apigee_m10n_teams/src/MonetizationTeams.php
@@ -33,6 +33,7 @@ use Drupal\apigee_m10n\Exception\SdkEntityLoadException;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\apigee_m10n_teams\Access\TeamPermissionAccessInterface;
 use Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanAccessControlHandler;
+use Drupal\apigee_m10n_teams\Entity\Access\TeamXRatePlanAccessControlHandler;
 use Drupal\apigee_m10n_teams\Entity\Access\TeamRatePlanSubscriptionAccessHandler;
 use Drupal\apigee_m10n_teams\Entity\Form\TeamPurchasedPlanForm;
 use Drupal\apigee_m10n_teams\Entity\Routing\MonetizationTeamsEntityRouteProvider;
@@ -41,6 +42,7 @@ use Drupal\apigee_m10n_teams\Entity\Storage\TeamPurchasedPlanStorage;
 use Drupal\apigee_m10n_teams\Entity\TeamProductBundle;
 use Drupal\apigee_m10n_teams\Entity\TeamsPurchasedPlan;
 use Drupal\apigee_m10n_teams\Entity\TeamsRatePlan;
+use Drupal\apigee_m10n_teams\Entity\TeamsXRatePlan;
 use Drupal\apigee_m10n_teams\Plugin\Field\FieldFormatter\TeamPurchasePlanFormFormatter;
 use Drupal\apigee_m10n_teams\Plugin\Field\FieldFormatter\TeamPurchasePlanLinkFormatter;
 use Drupal\apigee_m10n_teams\Plugin\Field\FieldWidget\CompanyTermsAndConditionsWidget;
@@ -137,6 +139,20 @@ class MonetizationTeams implements MonetizationTeamsInterface {
       $entity_types['rate_plan']->setHandlerClass('route_provider', $route_providers);
       $entity_types['rate_plan']->setHandlerClass('access', TeamRatePlanAccessControlHandler::class);
       $entity_types['rate_plan']->setHandlerClass('subscription_access', TeamRatePlanSubscriptionAccessHandler::class);
+    }
+
+    if (isset($entity_types['xrate_plan'])) {
+      // AppGroups use the `xrate_plan` entity type.
+      // Use our class to override the original entity class.
+      $entity_types['xrate_plan']->setClass(TeamsXRatePlan::class);
+      $entity_types['xrate_plan']->setLinkTemplate('team', '/teams/{team}/monetization/xproduct/{xproduct}/plan/{xrate_plan}');
+      $entity_types['xrate_plan']->setLinkTemplate('team-purchase', '/teams/{team}/monetization/xproduct/{xproduct}/plan/{xrate_plan}/purchase');
+      // Get the entity route providers.
+      $route_providers = $entity_types['xrate_plan']->getRouteProviderClasses();
+      // Override the `html` route provider.
+      $route_providers['html'] = MonetizationTeamsEntityRouteProvider::class;
+      $entity_types['xrate_plan']->setHandlerClass('route_provider', $route_providers);
+      $entity_types['xrate_plan']->setHandlerClass('access', TeamXRatePlanAccessControlHandler::class);
     }
 
     // Overrides for the purchased_plan entity.

--- a/modules/apigee_m10n_teams/src/Plugin/Menu/LocalTask/TeamPlansLocalTask.php
+++ b/modules/apigee_m10n_teams/src/Plugin/Menu/LocalTask/TeamPlansLocalTask.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\apigee_m10n_teams\Plugin\Menu\LocalTask;
+
+use Drupal\Core\Menu\LocalTaskDefault;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Provides dynamic tabs for team plans.
+ *
+ * @LocalTask(
+ *   id = "apigee_m10n_teams.team_plans",
+ *   route_name = "apigee_monetization.team_plans",
+ *   base_route = "entity.team.canonical",
+ *   parent_id = "apigee_m10n_teams.balance_and_plans",
+ *   weight = 1
+ * )
+ * @LocalTask(
+ *   id = "apigee_m10n_teams.team_xplans",
+ *   route_name = "apigee_monetization.team_xplans",
+ *   base_route = "entity.team.canonical",
+ *   parent_id = "apigee_m10n_teams.balance_and_plans",
+ *   weight = 1
+ * )
+ */
+class TeamPlansLocalTask extends LocalTaskDefault {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle(?Request $request = NULL): string {
+    $monetization = \Drupal::service('apigee_m10n.monetization');
+    if ($monetization->isOrganizationApigeeXorHybrid()) {
+      return 'Buy API';
+    }
+    else {
+      return 'Pricing & plans';
+    }
+  }
+
+}


### PR DESCRIPTION
For AppGroups monetized org added BuyApi tab which will list all the active rate plans of the organization. 
Fix #560