### PR TITLE
Add a robust wait loop to ensure ChromeDriver is fully ready

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -152,18 +152,33 @@ jobs:
         path: drupal/composer.*
         
     # Install drupal using minimal installation profile and enable the module.
-    - name: Install Drupal
+    - name: Install Drupal and Start Web Server
       run: |
-        cd drupal   
+        cd drupal
         php -d sendmail_path=$(which true); vendor/bin/drush --yes -v site-install minimal --db-url="$SIMPLETEST_DB"
         vendor/bin/drush rs 8000 &
 
-    - uses: nanasess/setup-chromedriver@v2
-
-    - run: |
+    - name: Start Xvfb and ChromeDriver (with Wait)
+      run: |
+        # Start Xvfb (Virtual Frame Buffer for headless testing)
         export DISPLAY=:99
-        chromedriver --url-base=/wd/hub &
-        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+
+        # --- CRITICAL FIX: Explicitly set the port to 9515 ---
+        chromedriver --url-base=/wd/hub --port=9515 &
+
+        # Add a robust wait loop to ensure ChromeDriver is fully ready
+        echo "Waiting for ChromeDriver to be ready on port 9515..."
+        # We also wait for the specific 'status' URL, which should return JSON when ready.
+        timeout 60 bash -c 'until curl --silent --fail http://127.0.0.1:9515/wd/hub/status; do sleep 1; done'
+
+        if [ $? -ne 0 ]; then
+          echo "Error: ChromeDriver failed to start and respond on port 9515 within 60 seconds."
+          # Capture logs/status if possible before failing
+          curl http://127.0.0.1:9515/wd/hub/status || true
+          exit 1
+        fi
+        echo "ChromeDriver is ready on 9515. Running tests."
 
     - name: "Run PHPUnit tests"
       if: ${{ matrix.drupal-core != '10.4.x' || matrix.php-version != '8.2' }}


### PR DESCRIPTION
Fix #588 