### PR TITLE
Fix Trigger_error() must be one of E_USER_DEPRECATED and Prophecy\Exception\Call\UnexpectedCallException: Unexpected method call on Double\RouteMatchInterface\P1

### DIFF
--- a/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
@@ -112,7 +112,7 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
 
     $this->queueApigeexDeveloperResponse($this->developer);
     $this->stack->queueMockResponse([
-      'get-apigeex-prepaid-balances' => [
+      'get-apigeex-prepaid-balances' => (object) [
         "currency_code" => 'AUD',
         "current_units_aud" => "20",
         "current_nano_aud" => "560000000",
@@ -140,7 +140,7 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
 
     $this->queueApigeexDeveloperResponse($this->developer);
     $this->stack->queueMockResponse([
-      'get-apigeex-prepaid-balances' => [
+      'get-apigeex-prepaid-balances' => (object) [
         "current_units_aud" => "20",
         "current_nano_aud" => "560000000",
 

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
@@ -111,20 +111,17 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
     $this->stack->queueMockResponse(['get-apigeex-billing-type']);
 
     $this->queueApigeexDeveloperResponse($this->developer);
-    $prepaid_balances = [
-      "currency_code" => 'AUD',
-      "current_units_aud" => "20",
-      "current_nano_aud" => "560000000",
-      "currency_code" => 'USD',
-      "current_units_usd" => "15",
-      "current_nano_usd" => "340000000",
-    ];
-    // TODO: remove this condition when Drupal 10 is no longer supported.
-    // @see https://www.drupal.org/project/apigee_m10n/issues/3443889
-    if (version_compare(\Drupal::VERSION, '11.2.0-dev', '>=')) {
-      $prepaid_balances = (object) $prepaid_balances;
-    }
-    $this->stack->queueMockResponse(['get-apigeex-prepaid-balances' => $prepaid_balances]);
+    $this->stack->queueMockResponse([
+      'get-apigeex-prepaid-balances' => [
+        "currency_code" => 'AUD',
+        "current_units_aud" => "20",
+        "current_nano_aud" => "560000000",
+
+        "currency_code" => 'USD',
+        "current_units_usd" => "15",
+        "current_nano_usd" => "340000000",
+      ],
+    ]);
 
     $this->drupalGet(Url::fromRoute('apigee_monetization.xbilling', [
       'user' => $this->developer->id(),
@@ -142,7 +139,15 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
     $this->stack->queueMockResponse(['get-apigeex-billing-type']);
 
     $this->queueApigeexDeveloperResponse($this->developer);
-    $this->stack->queueMockResponse(['get-apigeex-prepaid-balances' => $prepaid_balances]);
+    $this->stack->queueMockResponse([
+      'get-apigeex-prepaid-balances' => [
+        "current_units_aud" => "20",
+        "current_nano_aud" => "560000000",
+
+        "current_units_usd" => "15",
+        "current_nano_usd" => "340000000",
+      ],
+    ]);
     $this->drupalGet(Url::fromRoute('apigee_monetization.xbilling', [
       'user' => $this->developer->id(),
     ]));

--- a/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/Functional/ApigeeX/AddCreditPermissionsTest.php
@@ -111,17 +111,20 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
     $this->stack->queueMockResponse(['get-apigeex-billing-type']);
 
     $this->queueApigeexDeveloperResponse($this->developer);
-    $this->stack->queueMockResponse([
-      'get-apigeex-prepaid-balances' => (object) [
-        "currency_code" => 'AUD',
-        "current_units_aud" => "20",
-        "current_nano_aud" => "560000000",
-
-        "currency_code" => 'USD',
-        "current_units_usd" => "15",
-        "current_nano_usd" => "340000000",
-      ],
-    ]);
+    $prepaid_balances = [
+      "currency_code" => 'AUD',
+      "current_units_aud" => "20",
+      "current_nano_aud" => "560000000",
+      "currency_code" => 'USD',
+      "current_units_usd" => "15",
+      "current_nano_usd" => "340000000",
+    ];
+    // TODO: remove this condition when Drupal 10 is no longer supported.
+    // @see https://www.drupal.org/project/apigee_m10n/issues/3443889
+    if (version_compare(\Drupal::VERSION, '11.2.0-dev', '>=')) {
+      $prepaid_balances = (object) $prepaid_balances;
+    }
+    $this->stack->queueMockResponse(['get-apigeex-prepaid-balances' => $prepaid_balances]);
 
     $this->drupalGet(Url::fromRoute('apigee_monetization.xbilling', [
       'user' => $this->developer->id(),
@@ -139,15 +142,7 @@ class AddCreditPermissionsTest extends AddCreditFunctionalTestBase {
     $this->stack->queueMockResponse(['get-apigeex-billing-type']);
 
     $this->queueApigeexDeveloperResponse($this->developer);
-    $this->stack->queueMockResponse([
-      'get-apigeex-prepaid-balances' => (object) [
-        "current_units_aud" => "20",
-        "current_nano_aud" => "560000000",
-
-        "current_units_usd" => "15",
-        "current_nano_usd" => "340000000",
-      ],
-    ]);
+    $this->stack->queueMockResponse(['get-apigeex-prepaid-balances' => $prepaid_balances]);
     $this->drupalGet(Url::fromRoute('apigee_monetization.xbilling', [
       'user' => $this->developer->id(),
     ]));

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditPrepaidBalanceToAnyDeveloperTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/AddCreditPrepaidBalanceToAnyDeveloperTest.php
@@ -117,11 +117,10 @@ class AddCreditPrepaidBalanceToAnyDeveloperTest extends AddCreditFunctionalJavas
       "{$this->accountUser->get('first_name')->value} {$this->accountUser->get('last_name')->value}"
     );
 
-    $this->assertCount(
-      2,
-      array_count_values($this->getOptions(AddCreditConfig::TARGET_FIELD_NAME)),
-      'Developer count'
-    );
+    $select_field = $this->assertSession()->selectExists(AddCreditConfig::TARGET_FIELD_NAME);
+    $options = $select_field->findAll('xpath', '//option');
+
+    $this->assertCount(2, $options, 'Developer count');
   }
 
 }

--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/ApigeeX/AddCreditPrepaidBalanceToAnyDeveloperTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/ApigeeX/AddCreditPrepaidBalanceToAnyDeveloperTest.php
@@ -120,11 +120,10 @@ class AddCreditPrepaidBalanceToAnyDeveloperTest extends AddCreditFunctionalJavas
       "{$this->accountUser->get('first_name')->value} {$this->accountUser->get('last_name')->value}"
     );
 
-    $this->assertCount(
-      2,
-      array_count_values($this->getOptions(AddCreditConfig::TARGET_FIELD_NAME)),
-      'Developer count'
-    );
+    $select_field = $this->assertSession()->selectExists(AddCreditConfig::TARGET_FIELD_NAME);
+    $options = $select_field->findAll('xpath', '//option');
+
+    $this->assertCount(2, $options, 'Developer count');
   }
 
 }

--- a/modules/apigee_m10n_teams/tests/src/Traits/TeamProphecyTrait.php
+++ b/modules/apigee_m10n_teams/tests/src/Traits/TeamProphecyTrait.php
@@ -20,6 +20,7 @@
 namespace Drupal\Tests\apigee_m10n_teams\Traits;
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\Routing\Route;
 
 /**
  * Tests the team permission access checker.
@@ -40,6 +41,7 @@ trait TeamProphecyTrait {
     $route_match->getRouteName()->willReturn('entity.team.canonical');
     $route_match->getParameter('team')->willReturn($team);
     $route_match->getParameter('user')->willReturn(NULL);
+    $route_match->getRouteObject()->willReturn(new Route('/path'));
     $this->container->set('current_route_match', $route_match->reveal());
     // The `apigee_m10n_teams_entity_type_alter` will have already loaded the
     // `apigee_m10n.teams` service so we need to make sure it is reloaded.


### PR DESCRIPTION
Fix #590 & #594

Fixes 2 issues:
1. Trigger_error() must be one of E_USER_DEPRECATED, removed depreciated function getOptions()
2. Prophecy\Exception\Call\UnexpectedCallException: Unexpected method call on Double\RouteMatchInterface\P1:
