### PR TITLE
Fix Failing Unit Test Error: Billing type saved message not found

### DIFF
--- a/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/ApigeeX/UpdateBillingTypeTest.php
+++ b/modules/apigee_m10n_add_credit/tests/src/FunctionalJavascript/ApigeeX/UpdateBillingTypeTest.php
@@ -155,7 +155,7 @@ class UpdateBillingTypeTest extends AddCreditFunctionalJavascriptTestBase {
       ],
     ]);
 
-    $this->assertSession()->responseContains('Billing type of the user is saved.');
+    $this->assertSession()->waitForText('Billing type of the user is saved.');
 
   }
 


### PR DESCRIPTION
Fix error Billing type saved message not found