### PR TITLE
Fix unit test error 'unable to find the wrapper private'

### DIFF
--- a/tests/src/Kernel/ApigeeX/Access/AccessKernelTest.php
+++ b/tests/src/Kernel/ApigeeX/Access/AccessKernelTest.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\Tests\apigee_m10n\Kernel\ApigeeX\Access;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\Session\UserSession;
 use Drupal\Core\Url;
@@ -111,6 +112,20 @@ class AccessKernelTest extends MonetizationKernelTestBase {
     $this->stack->reset();
     $this->xrate_plan = $this->createRatePlan($this->xproduct);
     $this->stack->reset();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    // Ensure the private stream wrapper service is registered in the container
+    // for this test. This is sometimes necessary in kernel tests if the
+    // full module set isn't loaded.
+    if (!$container->hasDefinition('stream_wrapper.private')) {
+      $container->register('stream_wrapper.private', 'Drupal\Core\StreamWrapper\PrivateStream')
+        ->addTag('stream_wrapper', ['scheme' => 'private']);
+    }
   }
 
   /**

--- a/tests/src/Kernel/ApigeeX/Controller/ProductAdminListingTest.php
+++ b/tests/src/Kernel/ApigeeX/Controller/ProductAdminListingTest.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\Tests\apigee_m10n\Kernel\ApigeeX\Controller;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Url;
 use Drupal\Tests\apigee_m10n\Kernel\ApigeeX\MonetizationKernelTestBase;
 use Symfony\Component\HttpFoundation\Request;
@@ -52,6 +53,20 @@ class ProductAdminListingTest extends MonetizationKernelTestBase {
    * @var \Drupal\apigee_m10n\Entity\XProductInterface[]
    */
   protected $xproducts;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    // Ensure the private stream wrapper service is registered in the container
+    // for this test. This is sometimes necessary in kernel tests if the
+    // full module set isn't loaded.
+    if (!$container->hasDefinition('stream_wrapper.private')) {
+      $container->register('stream_wrapper.private', 'Drupal\Core\StreamWrapper\PrivateStream')
+        ->addTag('stream_wrapper', ['scheme' => 'private']);
+    }
+  }
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/ApigeeX/MonetizationKernelTestBase.php
+++ b/tests/src/Kernel/ApigeeX/MonetizationKernelTestBase.php
@@ -72,6 +72,11 @@ class MonetizationKernelTestBase extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    // Set the private file path for the test environment.
+    $this->setSetting('file_private_path', $this->vfsRoot->url() . '/private');
+    // Rebuild the container to apply the new setting.
+    $this->container->get('kernel')->rebuildContainer();
+
     $this->installConfig(['apigee_edge', 'apigee_m10n']);
 
     $this->baseSetUp();

--- a/tests/src/Kernel/ApigeeX/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
+++ b/tests/src/Kernel/ApigeeX/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php
@@ -19,11 +19,14 @@
 
 namespace Drupal\Tests\apigee_m10n\Kernel\ApigeeX\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Tests\apigee_m10n\Kernel\ApigeeX\MonetizationKernelTestBase;
 use Drupal\apigee_m10n\MonetizationInterface;
 use Drupal\apigee_m10n\Plugin\Field\FieldFormatter\MonetizationDeveloperFormatter;
 use Drupal\apigee_m10n\Plugin\Field\FieldType\MonetizationDeveloperFieldItem;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Site\Settings;
 
 /**
  * Test the `apigee_monetization_developer` field formatter.
@@ -77,11 +80,50 @@ class MonetizationDeveloperFormatterKernelTest extends MonetizationKernelTestBas
 
   /**
    * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    // Ensure the private stream wrapper service is registered in the container
+    // for this test. This is sometimes necessary in kernel tests if the
+    // full module set isn't loaded.
+    if (!$container->hasDefinition('stream_wrapper.private')) {
+      $container->register('stream_wrapper.private', 'Drupal\Core\StreamWrapper\PrivateStream')
+        ->addTag('stream_wrapper', ['scheme' => 'private']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Exception
    */
   protected function setUp(): void {
     parent::setUp();
+
+    // At this point, parent::setUp() should have run, and the register()
+    // method above should have been called, ensuring the stream_wrapper.private
+    // service definition exists.
+    // The apigee_edge base classes likely set 'file_private_path'
+    // to 'vfs://root/private'.
+    if (!in_array('private', stream_get_wrappers())) {
+      $settings = Settings::getInstance();
+      $actual_private_path = $settings ? $settings->get('file_private_path') : 'Settings service not available';
+      throw new \RuntimeException(
+          "The 'private' stream wrapper is NOT registered after parent::setUp() and register(). " .
+          "Actual 'file_private_path' setting: " . var_export($actual_private_path, TRUE)
+      );
+    }
+
+    // Get the file system service.
+    $file_system = $this->container->get('file_system');
+    $options = FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS;
+
+    // Prepare the directories within the file system (likely VFS).
+    $oauth_uri = 'private://apigee/oauth';
+    if (!$file_system->prepareDirectory($oauth_uri, $options)) {
+      throw new \RuntimeException("Failed to create directory at " . $oauth_uri);
+    }
 
     $this->installEntitySchema('user');
     $this->installSchema('user', ['users_data']);


### PR DESCRIPTION
Fix Unit Test error : 

> /home/runner/work/apigee-m1***n-drupal/apigee-m1***n-drupal/drupal/modules/contrib/apigee_edge/src/OauthTokenFileStorage.php:267
> file_exists(): Unable to find the wrapper "private" - did you forget to enable it when you configured PHP?
> 
> Triggered by:
> 
> * Drupal\Tests\apigee_m1***n\Kernel\ApigeeX\Access\AccessKernelTest::testAll
>   /home/runner/work/apigee-m1***n-drupal/apigee-m1***n-drupal/drupal/modules/contrib/apigee_m1***n/tests/src/Kernel/ApigeeX/Access/AccessKernelTest.php:119
> 
> * Drupal\Tests\apigee_m1***n\Kernel\ApigeeX\Controller\ProductAdminListingTest::testPage
>   /home/runner/work/apigee-m1***n-drupal/apigee-m1***n-drupal/drupal/modules/contrib/apigee_m1***n/tests/src/Kernel/ApigeeX/Controller/ProductAdminListingTest.php:1***
> 
> * Drupal\Tests\apigee_m1***n\Kernel\ApigeeX\Plugin\Field\FieldFormatter\MonetizationDeveloperFormatterKernelTest::testView
>   /home/runner/work/apigee-m1***n-drupal/apigee-m1***n-drupal/drupal/modules/contrib/apigee_m1***n/tests/src/Kernel/ApigeeX/Plugin/Field/FieldFormatter/MonetizationDeveloperFormatterKernelTest.php:128