### PR TITLE
Fix translatable string as a category for field type is deprecated in drupal 11

### DIFF
--- a/src/Plugin/Field/FieldType/ConsumptionPricingRatesFieldItem.php
+++ b/src/Plugin/Field/FieldType/ConsumptionPricingRatesFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   label = @Translation("Consumption Rates"),
  *   description = @Translation("Stores a decimal number and a three letter currency code."),
  *   no_ui = TRUE,
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   default_formatter = "apigee_rate_plan_consumption_rates",
  * )
  */

--- a/src/Plugin/Field/FieldType/DatestampFieldItem.php
+++ b/src/Plugin/Field/FieldType/DatestampFieldItem.php
@@ -30,7 +30,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_datestamp",
  *   label = @Translation("Apigee Date"),
  *   description = @Translation("An entity field containing a date."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_widget = "apigee_datestamp",
  *   default_formatter = "apigee_datestamp"

--- a/src/Plugin/Field/FieldType/FixedRecurringFeeFieldItem.php
+++ b/src/Plugin/Field/FieldType/FixedRecurringFeeFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_rate_plan_fixed_recurringfee",
  *   label = @Translation("Fixed recurring fee field item"),
  *   description = @Translation("Apigee X fixed recurring fee detail."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_rate_plan_fixed_recurringfee"
  * )

--- a/src/Plugin/Field/FieldType/MonetizationDeveloperFieldItem.php
+++ b/src/Plugin/Field/FieldType/MonetizationDeveloperFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_monetization_developer",
  *   label = @Translation("Apigee developer"),
  *   description = @Translation("Apigee monetization developer"),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_monetization_developer"
  * )

--- a/src/Plugin/Field/FieldType/OrganizationFieldItem.php
+++ b/src/Plugin/Field/FieldType/OrganizationFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_organization",
  *   label = @Translation("Apigee organization"),
  *   description = @Translation("Apigee organization"),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_organization"
  * )

--- a/src/Plugin/Field/FieldType/PriceItem.php
+++ b/src/Plugin/Field/FieldType/PriceItem.php
@@ -32,7 +32,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   label = @Translation("Price"),
  *   description = @Translation("Stores a decimal number and a three letter currency code."),
  *   no_ui = TRUE,
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   default_formatter = "apigee_price",
  * )
  */

--- a/src/Plugin/Field/FieldType/PurchaseProductFieldItem.php
+++ b/src/Plugin/Field/FieldType/PurchaseProductFieldItem.php
@@ -31,7 +31,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_purchase_product",
  *   label = @Translation("Purchase product"),
  *   description = @Translation("Purchase product computed item."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_purchase_product_form"
  * )

--- a/src/Plugin/Field/FieldType/RatePlanDetailsFieldItem.php
+++ b/src/Plugin/Field/FieldType/RatePlanDetailsFieldItem.php
@@ -35,7 +35,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_rate_plan_details",
  *   label = @Translation("Rate plan detail field item"),
  *   description = @Translation("Apigee rate plan detail."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_rate_plan_details"
  * )

--- a/src/Plugin/Field/FieldType/RatePlanXFeeFieldItem.php
+++ b/src/Plugin/Field/FieldType/RatePlanXFeeFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_rate_plan_xfee",
  *   label = @Translation("Setup Fee field item"),
  *   description = @Translation("Apigee X Setup fee detail."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_rate_plan_xfee"
  * )

--- a/src/Plugin/Field/FieldType/RevenueShareRatesFieldItem.php
+++ b/src/Plugin/Field/FieldType/RevenueShareRatesFieldItem.php
@@ -33,7 +33,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_rate_plan_revenue_rates",
  *   label = @Translation("Revenue Share rates field item"),
  *   description = @Translation("Apigee X Revenue Share rates detail."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_rate_plan_revenue_rates"
  * )

--- a/src/Plugin/Field/FieldType/SupportedCurrencylFieldItem.php
+++ b/src/Plugin/Field/FieldType/SupportedCurrencylFieldItem.php
@@ -34,7 +34,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_currency",
  *   label = @Translation("Apigee currency field item"),
  *   description = @Translation("Apigee currency."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_currency"
  * )

--- a/src/Plugin/Field/FieldType/TermsAndConditionsFieldItem.php
+++ b/src/Plugin/Field/FieldType/TermsAndConditionsFieldItem.php
@@ -31,7 +31,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_tnc",
  *   label = @Translation("Apigee terms and conditions"),
  *   description = @Translation("Apigee terms and conditions"),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_tnc_default"
  * )


### PR DESCRIPTION
  Fix issue :  #611
Using a translatable string as a category for field type is deprecated in drupal:1***.2.*** and is removed from drupal:11.***.***. See https://www.drupal.org/node/3375748
    1352x in AddCreditCustomAmountTest::testPriceRangeFieldValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1352x in AddCreditCustomAmountTest::testMinimumAmountValidationOnCheckout from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1***14x in AddCreditCustomAmountTest::testUnitPriceValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1***14x in AddCreditCustomAmountTest::testPriceRangeFieldValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript\ApigeeX
    1***14x in AddCreditCustomAmountTest::testUnitPriceValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript\ApigeeX
    ...