### PR TITLE
Fix category translation in PurchaseFieldItem.php

### DIFF
--- a/src/Plugin/Field/FieldType/PurchaseFieldItem.php
+++ b/src/Plugin/Field/FieldType/PurchaseFieldItem.php
@@ -31,7 +31,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "apigee_purchase",
  *   label = @Translation("Purchase rate plan"),
  *   description = @Translation("Purchase rate plan computed item."),
- *   category = @Translation("Apigee"),
+ *   category = "Apigee",
  *   no_ui = TRUE,
  *   default_formatter = "apigee_purchase_plan_link"
  * )


### PR DESCRIPTION
  Fix issue :  #611
Using a translatable string as a category for field type is deprecated in drupal:1***.2.*** and is removed from drupal:11.***.***. See https://www.drupal.org/node/3375748
    1352x in AddCreditCustomAmountTest::testPriceRangeFieldValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1352x in AddCreditCustomAmountTest::testMinimumAmountValidationOnCheckout from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1***14x in AddCreditCustomAmountTest::testUnitPriceValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript
    1***14x in AddCreditCustomAmountTest::testPriceRangeFieldValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript\ApigeeX
    1***14x in AddCreditCustomAmountTest::testUnitPriceValidation from Drupal\Tests\apigee_m1***n_add_credit\FunctionalJavascript\ApigeeX
    ...