### PR TITLE
Ignore deprecated warning already fixed in Drupal 11

### DIFF
--- a/.deprecation-ignore.txt
+++ b/.deprecation-ignore.txt
@@ -1,0 +1,53 @@
+# 1. MemoryBackend constructor
+%Calling Drupal\\Core\\Cache\\MemoryBackend::__construct\(\) without the \$time argument is deprecated%
+
+# 2. FileSystem::saveData() integer argument
+%Passing the \$fileExists argument as an integer to Drupal\\Core\\File\\FileSystem::saveData\(\) is deprecated%
+
+# 3. Key module storage_method
+%The key provider 'storage_method' definition entry is deprecated%
+
+# 4. Timestamp formatter plugin settings (Note the double spaces)
+%Using the 'timestamp' formatter plugin  without the 'tooltip' and 'time_diff' settings is deprecated%
+
+# 5. FormElement::preRenderAjaxForm()
+%\\Drupal\\Core\\Render\\Element\\FormElement::preRenderAjaxForm\(\) is deprecated%
+
+# 6. Yaml parser class setting
+%The "yaml_parser_class" setting is deprecated%
+
+# 7. Tabbable jQuery shim asset library
+%The core/tabbable.jquery.shim asset library is deprecated%
+
+# 8. Behat Mink ElementInterface return types (getText and waitFor)
+%Method "Behat\\Mink\\Element\\ElementInterface::.*" might add ".*" as a native return type declaration%
+
+# 9. FormElement methods (valueCallback, processAjaxForm, processGroup, preRenderGroup, setAttributes)
+%\\Drupal\\Core\\Render\\Element\\FormElement::(valueCallback|processAjaxForm|processGroup|preRenderGroup|setAttributes)\(\) is deprecated%
+
+# 10. Commerce views numeric to entity_target_id updates
+%The update to convert "numeric" arguments to "entity_target_id" for entity reference fields for view%
+
+# 11. Twig 3.12 spaceless filter deprecations across all templates
+%Since twig/twig 3.12: Twig Filter "spaceless" is deprecated%
+
+# 12. RenderElement::preRenderGroup()
+%\\Drupal\\Core\\Render\\Element\\RenderElement::preRenderGroup\(\) is deprecated%
+
+# 13. PHPUnit DefaultResultPrinter internal class warning
+%The "PHPUnit\\TextUI\\DefaultResultPrinter" class is considered internal%
+
+# 14. DrupalListener interface / trait deprecations
+%The "Drupal\\Tests\\Listeners\\DrupalListener" class (implements|uses) "PHPUnit\\Framework\\TestListener.*" that is deprecated%
+
+# 15. PHPUnit TestCase::addWarning() internal method warning
+%The "PHPUnit\\Framework\\TestCase::addWarning\(\)" method is considered internal%
+
+# 16. Symfony ContainerAwareTrait deprecation
+%Since symfony/dependency-injection 6.4: "Symfony\\Component\\DependencyInjection\\ContainerAwareTrait" is deprecated%
+
+# 17. IteratorAggregate native return type warnings (Map, ContentEntityBase, etc.)
+%Method "IteratorAggregate::getIterator\(\)" might add ".*" as a native return type declaration%
+
+# 18. ModuleHandler::getName() deprecation
+%Drupal\\Core\\Extension\\ModuleHandler::getName\(\) is deprecated%

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,11 +53,15 @@ jobs:
 
     steps:
 
-    - name: Disable deprecations check for PR
-      if: github.event_name != 'schedule'
+    - name: Configure Deprecations Check
       run: |
-        echo "Disable deprecations check"
-        echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $GITHUB_ENV
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          echo "Scheduled cron run: Using precision deprecation filters"
+          echo "SYMFONY_DEPRECATIONS_HELPER=ignoreFile=./modules/contrib/apigee_m10n/.deprecation-ignore.txt" >> $GITHUB_ENV
+        else
+          echo "Completely disabling deprecation check"
+          echo "SYMFONY_DEPRECATIONS_HELPER=disabled" >> $GITHUB_ENV
+        fi
 
     - name: "Install PHP"
       uses: "shivammathur/setup-php@v2"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/.editorconfig
 !.gitkeep
 !/.circleci
+!/.deprecation-ignore.txt
 
 ## Ignore working copies of dist files ##
 phpcs.xml


### PR DESCRIPTION
This PR establishes a precision deprecation baseline for our test suite to clean up thousands of noisy upstream warnings triggered during testing. 

These specific deprecation warnings stem from changes preparing for Drupal 11 (such as the `MemoryBackend` constructor and `FileSystem::saveData()` modifications). Because these compatibility updates are already natively handled inside our dedicated Drupal 11 development branches, we do not need them failing or cluttering our active test pipelines here.

### Key Changes
1. **Added `.deprecation-ignore.txt`**: Created a centralized filter configuration containing targeted regular expressions to suppress noisy, known upstream deprecations (e.g., Drupal 11 `MemoryBackend` constructor, Twig 3.12 `spaceless` filter, PHPUnit runner internal assertions, and Symfony 6.4 `ContainerAwareTrait` warnings).
2. **Updated GitHub CI Workflow (`test_and_lint.yml`)**: 
   - **For Nightly Schedules (Cron)**: Configured the workflow to utilize our precision `.deprecation-ignore.txt` baseline. This ensures that our nightly builds will aggressively catch *new* deprecations introduced by upstream dependencies while safely ignoring the known, expected noise.