### PR TITLE
update PriceRange element to extend FormElementBase

### DIFF
--- a/modules/apigee_m10n_add_credit/src/Element/PriceRange.php
+++ b/modules/apigee_m10n_add_credit/src/Element/PriceRange.php
@@ -21,7 +21,7 @@
 namespace Drupal\apigee_m10n_add_credit\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element\FormElement;
+use Drupal\Core\Render\Element\FormElementBase;
 
 /**
  * Provides a price range form element.
@@ -47,7 +47,7 @@ use Drupal\Core\Render\Element\FormElement;
  *
  * @FormElement("price_range")
  */
-class PriceRange extends FormElement {
+class PriceRange extends FormElementBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Updated the PriceRange custom form element plugin to inherit from FormElementBase instead of FormElement. This resolves class compatibility errors in newer versions of Drupal where FormElement behavior has changed or 
strict typing expects FormElementBase for standard form inputs.

- Updated namespace use statement to FormElementBase
- Updated PriceRange class definition to extend FormElementBase