### PR TITLE
Modify PHPUnit command to disable deprecation checking for codecov test run

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -178,7 +178,7 @@ jobs:
       run: |
         cd drupal
         cp modules/contrib/apigee_m10n/phpunit.core.xml.dist core/phpunit.xml
-        // Force-disable deprecation checking for codecov test
+        # Force-disable deprecation checking for codecov test
         SYMFONY_DEPRECATIONS_HELPER=disabled vendor/bin/phpunit -c core --color --group apigee_m10n --testsuite unit,kernel,functional,functional-javascript --coverage-clover /tmp/coverage_${{ matrix.instance-type }}.xml modules/contrib/apigee_m10n
         
     - name: Artifacts

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -178,7 +178,8 @@ jobs:
       run: |
         cd drupal
         cp modules/contrib/apigee_m10n/phpunit.core.xml.dist core/phpunit.xml
-        vendor/bin/phpunit -c core --color --group apigee_m10n --testsuite unit,kernel,functional,functional-javascript --coverage-clover /tmp/coverage_${{ matrix.instance-type }}.xml modules/contrib/apigee_m10n
+        // Force-disable deprecation checking for codecov test
+        SYMFONY_DEPRECATIONS_HELPER=disabled vendor/bin/phpunit -c core --color --group apigee_m10n --testsuite unit,kernel,functional,functional-javascript --coverage-clover /tmp/coverage_${{ matrix.instance-type }}.xml modules/contrib/apigee_m10n
         
     - name: Artifacts
       if: failure()


### PR DESCRIPTION
Disable deprecation checking for codecov tests in PHPUnit command.

Ignoring the following errors
```
Remaining self deprecation notices (5)

  1x: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Drupal\Core\TypedData\Plugin\DataType\ItemList" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Clover::process from SebastianBergmann\CodeCoverage\Report

  1x: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "Drupal\Core\TypedData\Plugin\DataType\ItemList" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Clover::process from SebastianBergmann\CodeCoverage\Report

  1x: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Drupal\Core\TypedData\Plugin\DataType\ItemList" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Clover::process from SebastianBergmann\CodeCoverage\Report

  1x: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "Drupal\Core\TypedData\Plugin\DataType\ItemList" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Clover::process from SebastianBergmann\CodeCoverage\Report

  1x: Method "Countable::count()" might add "int" as a native return type declaration in the future. Do the same in implementation "Drupal\Core\TypedData\Plugin\DataType\ItemList" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in Clover::process from SebastianBergmann\CodeCoverage\Report

```